### PR TITLE
CHORE: Eslint를 통한 Import 순서 자동 정렬 설정하기

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,17 +31,31 @@
     "import/order": [
       "error",
       {
-        "groups": ["builtin", "external", "internal"],
+        "groups": ["builtin", "external", "internal", "object"],
         "pathGroups": [
-          { "pattern": "react", "group": "builtin", "position": "after" },
-          { "pattern": "react-dom", "group": "builtin", "position": "after" },
+          { "pattern": "react", "group": "builtin" },
+          { "pattern": "react-dom", "group": "builtin" },
           {
-            "pattern": "react-router-dom",
-            "group": "builtin",
+            "pattern": "react-router**",
+            "group": "builtin"
+          },
+          {
+            "pattern": "@components/**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "@customTypes/**",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@**/**",
+            "group": "external",
             "position": "after"
           }
         ],
-        "pathGroupsExcludedImportTypes": ["react", "react-dom", "react-router-dom"],
+        "pathGroupsExcludedImportTypes": ["react", "react-dom", "react-router"],
         "newlines-between": "always",
         "alphabetize": {
           "order": "asc",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
     "es2021": true,
     "jest": true
   },
-  "plugins": ["react", "@typescript-eslint"],
+  "plugins": ["react", "@typescript-eslint", "import"],
   "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "rules": {
     "react/react-in-jsx-scope": "off",
@@ -20,6 +20,34 @@
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/strict-boolean-expressions": "off"
+    "@typescript-eslint/strict-boolean-expressions": "off",
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": true,
+        "ignoreDeclarationSort": true
+      }
+    ],
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal"],
+        "pathGroups": [
+          { "pattern": "react", "group": "builtin", "position": "after" },
+          { "pattern": "react-dom", "group": "builtin", "position": "after" },
+          {
+            "pattern": "react-router-dom",
+            "group": "builtin",
+            "position": "after"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["react", "react-dom", "react-router-dom"],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@typescript-eslint/parser": "^5.48.0",
         "eslint": "^8.31.0",
         "eslint-config-prettier": "^8.6.0",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.8.1"
       }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@typescript-eslint/parser": "^5.48.0",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.1"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
+import { Route, Routes } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 
 import Main from '@pages/Main';
 import Mypage from '@pages/Mypage';
 import Room from '@pages/Room';
-import { Route, Routes } from 'react-router';
 
 const App = (): JSX.Element => {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { BrowserRouter } from 'react-router-dom';
-import { Route, Routes } from 'react-router';
+
 import Main from '@pages/Main';
-import Room from '@pages/Room';
 import Mypage from '@pages/Mypage';
+import Room from '@pages/Room';
+import { Route, Routes } from 'react-router';
 
 const App = (): JSX.Element => {
   return (

--- a/src/apis/userApi.ts
+++ b/src/apis/userApi.ts
@@ -1,5 +1,6 @@
-import { noAuthInstance, authInstance } from './instance';
 import { MyProfileResponse } from '@customTypes/userType';
+
+import { authInstance, noAuthInstance } from './instance';
 
 const USER_API = '/api/users';
 

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,9 +1,9 @@
 import { useRef } from 'react';
-
 import { createPortal } from 'react-dom';
 
-import useClickAway from '@hooks/useClickAway';
 import styled from 'styled-components';
+
+import useClickAway from '@hooks/useClickAway';
 
 interface ModalProps {
   visible: boolean;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,7 +1,9 @@
-import { createPortal } from 'react-dom';
-import styled from 'styled-components';
-import useClickAway from '@hooks/useClickAway';
 import { useRef } from 'react';
+
+import { createPortal } from 'react-dom';
+
+import useClickAway from '@hooks/useClickAway';
+import styled from 'styled-components';
 
 interface ModalProps {
   visible: boolean;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
-import App from './App';
 import ReactDOM from 'react-dom/client';
+
+import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(<App />);

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,5 +1,6 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
-import type { RootState, AppDispatch } from './store';
+
+import type { AppDispatch, RootState } from './store';
 
 export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/redux/modules/userSlice.tsx
+++ b/src/redux/modules/userSlice.tsx
@@ -1,6 +1,5 @@
-import { createSlice } from '@reduxjs/toolkit';
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import userApi from '@apis/userApi';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   user: null,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,4 +1,5 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
+
 import userSlice from './modules/userSlice';
 
 const rootReducer = combineReducers({


### PR DESCRIPTION
### Issue

- resolves #7 

<br>


### 작업 내용

- `npm install -D eslint-plugin-import`
- import 순서 룰을 적용

![image](https://user-images.githubusercontent.com/76927397/211083267-e4acde8a-9787-4f84-827e-22a1a1e8cffb.png)

**순서는 다음과 같습니다**

- 내부모듈(또는 리액트 관련) `EX) react, react-router, react-router-dom`
- 외부 라이브러리 모듈
- 내부 파일 모듈 (type-alias 설정된)
- 내부 컴포넌트 모듈
- 내부 타입 모듈
- `sibiling 등 내부 모듈`

<br>

