### PR TITLE
FEAT: WebRTC를 통한 방의 사용자들간 커뮤니케이션

### DIFF
--- a/src/components/game/Cam.tsx
+++ b/src/components/game/Cam.tsx
@@ -2,15 +2,19 @@ import { useEffect, useRef } from 'react';
 
 import styled from 'styled-components';
 
+import CamButton from './CamButton';
+import MicButton from './MicButton';
+
 interface CamProps {
   userStream: MediaStream;
   nickname: string;
   audio?: boolean;
   video?: boolean;
   isMe?: boolean;
+  isHost?: boolean;
 }
 
-const Cam = ({ userStream, nickname, audio, video, isMe }: CamProps) => {
+const Cam = ({ userStream, nickname, audio, video, isMe, isHost }: CamProps) => {
   const videoRef: React.RefObject<HTMLVideoElement> | null = useRef(null);
 
   useEffect(() => {
@@ -22,7 +26,31 @@ const Cam = ({ userStream, nickname, audio, video, isMe }: CamProps) => {
 
   return (
     <CamLayout>
-      {userStream ? <Video ref={videoRef} autoPlay playsInline muted={isMe} /> : <EmptyVideo>{nickname}</EmptyVideo>}
+      {userStream ? (
+        <VideoBox>
+          <NameBox>
+            {isHost && '<방장>'}
+            {nickname}
+            {isMe && '[ME]'}
+          </NameBox>
+          <MediaFlexBox>
+            {isMe ? (
+              <>
+                <CamButton />
+                <MicButton />
+              </>
+            ) : (
+              <>
+                <button>오디오 {audio ? '켜짐' : '꺼짐'}</button>
+                <button>비디오 {video ? '켜짐' : '꺼짐'}</button>
+              </>
+            )}
+          </MediaFlexBox>
+          <Video ref={videoRef} autoPlay playsInline muted={isMe} />
+        </VideoBox>
+      ) : (
+        <EmptyVideo>{nickname}</EmptyVideo>
+      )}
     </CamLayout>
   );
 };
@@ -30,6 +58,22 @@ const Cam = ({ userStream, nickname, audio, video, isMe }: CamProps) => {
 const CamLayout = styled.div`
   border: 1px solid white;
   color: white;
+`;
+
+const NameBox = styled.div`
+  position: absolute;
+  top: 0;
+  background-color: black;
+`;
+
+const MediaFlexBox = styled.div`
+  position: absolute;
+  bottom: 0;
+  background-color: black;
+`;
+
+const VideoBox = styled.div`
+  position: relative;
 `;
 
 const Video = styled.video`

--- a/src/components/game/Cam.tsx
+++ b/src/components/game/Cam.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+import styled from 'styled-components';
+
+interface CamProps {
+  userStream: MediaStream;
+  nickname: string;
+  audio?: boolean;
+  video?: boolean;
+  isMe?: boolean;
+}
+
+const Cam = ({ userStream, nickname, audio, video, isMe }: CamProps) => {
+  const videoRef: React.RefObject<HTMLVideoElement> | null = useRef(null);
+
+  useEffect(() => {
+    if (!videoRef.current || !userStream) {
+      return;
+    }
+    videoRef.current.srcObject = userStream;
+  }, [userStream]);
+
+  return (
+    <CamLayout>
+      {userStream ? <Video ref={videoRef} autoPlay playsInline muted={isMe} /> : <EmptyVideo>{nickname}</EmptyVideo>}
+    </CamLayout>
+  );
+};
+
+const CamLayout = styled.div`
+  border: 1px solid white;
+  color: white;
+`;
+
+const Video = styled.video`
+  max-width: 100%;
+  max-height: 100%;
+`;
+const EmptyVideo = styled.div``;
+
+export default Cam;

--- a/src/components/game/CamButton.tsx
+++ b/src/components/game/CamButton.tsx
@@ -1,9 +1,11 @@
+import useStreamUpdateSocket from '@hooks/socket/useStreamUpdateSocket';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
 import { setUserCam } from '@redux/modules/userMediaSlice';
 
 const CamButton = () => {
   const { userCam, localDevice, userStreamRef } = useAppSelector((state) => state.userMedia);
   const dispatch = useAppDispatch();
+  const { emitUpdateUserStream } = useStreamUpdateSocket();
   const handleClick = () => {
     if (!localDevice.video || !userStreamRef?.current) {
       return;
@@ -11,6 +13,7 @@ const CamButton = () => {
     userStreamRef.current.getVideoTracks().forEach((track) => (track.enabled = !track.enabled));
     const changedCamState = !userCam;
     dispatch(setUserCam(changedCamState));
+    emitUpdateUserStream({ video: changedCamState });
   };
   return (
     <button onClick={handleClick} aria-label={`캠 ${userCam ? '켜짐' : '꺼짐'}`}>

--- a/src/components/game/CamButton.tsx
+++ b/src/components/game/CamButton.tsx
@@ -1,0 +1,22 @@
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { setUserCam } from '@redux/modules/userMediaSlice';
+
+const CamButton = () => {
+  const { userCam, localDevice, userStreamRef } = useAppSelector((state) => state.userMedia);
+  const dispatch = useAppDispatch();
+  const handleClick = () => {
+    if (!localDevice.video || !userStreamRef?.current) {
+      return;
+    }
+    userStreamRef.current.getVideoTracks().forEach((track) => (track.enabled = !track.enabled));
+    const changedCamState = !userCam;
+    dispatch(setUserCam(changedCamState));
+  };
+  return (
+    <button onClick={handleClick} aria-label={`캠 ${userCam ? '켜짐' : '꺼짐'}`}>
+      {userCam ? 'CAM켜짐' : 'CAM꺼짐'}
+    </button>
+  );
+};
+
+export default CamButton;

--- a/src/components/game/CamList.tsx
+++ b/src/components/game/CamList.tsx
@@ -1,14 +1,40 @@
+import { useEffect } from 'react';
+
 import styled from 'styled-components';
 
-import { useAppSelector } from '@redux/hooks';
+import { SUBSCRIBE } from '@constants/socket';
+import socketInstance from '@hooks/socket/socketInstance';
+import useStreamUpdateSocket from '@hooks/socket/useStreamUpdateSocket';
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { setUserCam, setUserMic } from '@redux/modules/userMediaSlice';
 
 import Cam from './Cam';
 
 // TODO: 사용자들의 캠 대신 이름으로 참여 여부를 먼저 나타냈다. 수정되어야 한다.
 const CamList = () => {
-  const { userStream, userCam, userMic } = useAppSelector((state) => state.userMedia);
+  const { userStream, userCam, userMic, userStreamRef } = useAppSelector((state) => state.userMedia);
   const { playerList, playerStreamMap } = useAppSelector((state) => state.playerMedia);
   const { user } = useAppSelector((state) => state.user);
+  const dispatch = useAppDispatch();
+  const { onUpdateUserStream, offUpdateUserStream } = useStreamUpdateSocket();
+
+  useEffect(() => {
+    // XXX: 우선은 끈 상태로 시작하게 했지만..???
+    if (userStreamRef?.current) {
+      dispatch(setUserCam(false));
+      dispatch(setUserMic(false));
+      userStreamRef.current.getAudioTracks().forEach((track) => (track.enabled = !track.enabled));
+      userStreamRef.current.getVideoTracks().forEach((track) => (track.enabled = !track.enabled));
+    }
+  }, []);
+
+  useEffect(() => {
+    onUpdateUserStream();
+    return () => {
+      offUpdateUserStream();
+    };
+  }, [playerList]);
+
   return (
     <CamListLayout>
       {playerList.map((player, index) => {

--- a/src/components/game/CamList.tsx
+++ b/src/components/game/CamList.tsx
@@ -7,10 +7,35 @@ import Cam from './Cam';
 // TODO: 사용자들의 캠 대신 이름으로 참여 여부를 먼저 나타냈다. 수정되어야 한다.
 const CamList = () => {
   const { userStream, userCam, userMic } = useAppSelector((state) => state.userMedia);
+  const { playerList, playerStreamMap } = useAppSelector((state) => state.playerMedia);
   const { user } = useAppSelector((state) => state.user);
   return (
     <CamListLayout>
-      {user && <Cam userStream={userStream} nickname={user.nickname} video={userCam} audio={userMic} isMe={true} />}
+      {playerList.map((player, index) => {
+        return (
+          <div key={player.userId}>
+            {player.userId === user?.userId ? (
+              <Cam
+                userStream={userStream}
+                nickname={user.nickname}
+                video={userCam}
+                audio={userMic}
+                isMe={true}
+                isHost={index === 0}
+              />
+            ) : (
+              <Cam
+                key={player.userId}
+                userStream={playerStreamMap[player.socketId]}
+                nickname={player.nickname}
+                video={player.video}
+                audio={player.audio}
+                isHost={index === 0}
+              />
+            )}
+          </div>
+        );
+      })}
     </CamListLayout>
   );
 };

--- a/src/components/game/CamList.tsx
+++ b/src/components/game/CamList.tsx
@@ -1,6 +1,27 @@
+import styled from 'styled-components';
+
+import { useAppSelector } from '@redux/hooks';
+
+import Cam from './Cam';
+
 // TODO: 사용자들의 캠 대신 이름으로 참여 여부를 먼저 나타냈다. 수정되어야 한다.
 const CamList = () => {
-  return <div></div>;
+  const { userStream, userCam, userMic } = useAppSelector((state) => state.userMedia);
+  const { user } = useAppSelector((state) => state.user);
+  return (
+    <CamListLayout>
+      {user && <Cam userStream={userStream} nickname={user.nickname} video={userCam} audio={userMic} isMe={true} />}
+    </CamListLayout>
+  );
 };
+
+const CamListLayout = styled.div`
+  gap: 10px;
+  height: 100%;
+  display: grid;
+  min-height: 470px;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+`;
 
 export default CamList;

--- a/src/components/game/MicButton.tsx
+++ b/src/components/game/MicButton.tsx
@@ -1,9 +1,12 @@
+import useStreamUpdateSocket from '@hooks/socket/useStreamUpdateSocket';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
 import { setUserMic } from '@redux/modules/userMediaSlice';
 
 const MicButton = () => {
   const { userMic, localDevice, userStreamRef } = useAppSelector((state) => state.userMedia);
   const dispatch = useAppDispatch();
+  const { emitUpdateUserStream } = useStreamUpdateSocket();
+
   const handleClick = () => {
     if (!localDevice.video || !userStreamRef?.current) {
       return;
@@ -11,6 +14,7 @@ const MicButton = () => {
     userStreamRef.current.getAudioTracks().forEach((track) => (track.enabled = !track.enabled));
     const changedCamState = !userMic;
     dispatch(setUserMic(changedCamState));
+    emitUpdateUserStream({ audio: changedCamState });
   };
   return (
     <button onClick={handleClick} aria-label={`마이크 ${userMic ? '켜짐' : '꺼짐'}`}>

--- a/src/components/game/MicButton.tsx
+++ b/src/components/game/MicButton.tsx
@@ -1,0 +1,22 @@
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { setUserMic } from '@redux/modules/userMediaSlice';
+
+const MicButton = () => {
+  const { userMic, localDevice, userStreamRef } = useAppSelector((state) => state.userMedia);
+  const dispatch = useAppDispatch();
+  const handleClick = () => {
+    if (!localDevice.video || !userStreamRef?.current) {
+      return;
+    }
+    userStreamRef.current.getAudioTracks().forEach((track) => (track.enabled = !track.enabled));
+    const changedCamState = !userMic;
+    dispatch(setUserMic(changedCamState));
+  };
+  return (
+    <button onClick={handleClick} aria-label={`마이크 ${userMic ? '켜짐' : '꺼짐'}`}>
+      {userMic ? 'MIC켜짐' : 'MIC꺼짐'}
+    </button>
+  );
+};
+
+export default MicButton;

--- a/src/components/home/RoomList.tsx
+++ b/src/components/home/RoomList.tsx
@@ -4,18 +4,21 @@ import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 
 import useGameSocket from '@hooks/socket/useGameSocket';
+import useLocalStream from '@hooks/useLocalStream';
 import { useAppSelector } from '@redux/hooks';
 
 const RoomList = () => {
   const navigate = useNavigate();
   const rooms = useAppSelector((state) => state.gameRoom);
   const { onBroadcastWholeRooms } = useGameSocket();
+  const { initLocalStream } = useLocalStream();
 
   useEffect(() => {
     onBroadcastWholeRooms();
   }, []);
 
-  const handleJoinRoomClick = (roomId: number) => {
+  const handleJoinRoomClick = async (roomId: number) => {
+    await initLocalStream();
     navigate('/room/' + roomId);
   };
 
@@ -41,6 +44,7 @@ const RoomListLayout = styled.div`
   flex-wrap: wrap;
   grid-column-gap: 16px;
   grid-row-gap: 16px;
+  color: white;
 `;
 
 const RoomCard = styled.div`

--- a/src/constants/socket.ts
+++ b/src/constants/socket.ts
@@ -1,15 +1,18 @@
-//TODO: webRTC 통신 관련 규칙을 추가하여야 한다.
-
 export const PUBLISH = Object.freeze({
   login: 'log-in', // 토큰을 넘겨주어 연결된 소켓에 대한 사용자가 누구인지 서버에 인식시킨다.
   createGame: 'create-room', // 방 생성 요청을 발행한다.
   joinGame: 'enter-room', // 방 입장 요청을 발행한다.
   leaveGame: 'leave-room', // 방 나가기 요청을 발행한다.
   sendChat: 'send-chat', // 채팅 보내기 요청을 발행한다.
+
+  // webRTC
+  webRTCIce: 'webrtc-ice',
+  webRTCOffer: 'webrtc-offer',
+  webRTCAnswer: 'webrtc-answer',
+  webRTCLeave: 'webrtc-leave',
 });
 
 export const SUBSCRIBE = Object.freeze({
-  //   welcomeUserEnteredRoom: 'welcome', // room-update 가 있다면 필요없다.
   showCreatedRoomIdForOwner: 'create-room', // 유저의 게임 생성 요청으로 생성된 아이디 정보를 알려준다.
   showRoomListForFirstUser: 'room-list', // 처음 홈페이지에 들어와 소켓에 연결된 유저들에게 방 목록 정보가 알려진다.
   broadcastRenewedRoomForHomeUsers: 'update-room-list', // 방 생성/삭제, 방의 유저 변동에 대한 정보 업데이트가 홈페이지의 모든 유저들에게 알려진다.
@@ -17,4 +20,10 @@ export const SUBSCRIBE = Object.freeze({
   receiveChat: 'receive-chat', // 유저의 방에서 발생된 채팅을 응답한다.
   login: 'log-in', // 로그인 성공 응답 메시지
   joinGame: 'enter-room', // 방 입장 시도에 대한 서버의 응답을 받는다.
+
+  // webRTC
+  webRTCIce: 'webrtc-ice',
+  webRTCOffer: 'webrtc-offer',
+  webRTCAnswer: 'webrtc-answer',
+  webRTCLeave: 'webrtc-leave',
 });

--- a/src/constants/socket.ts
+++ b/src/constants/socket.ts
@@ -10,6 +10,7 @@ export const PUBLISH = Object.freeze({
   webRTCOffer: 'webrtc-offer',
   webRTCAnswer: 'webrtc-answer',
   webRTCLeave: 'webrtc-leave',
+  updateUserStream: 'update-userstream',
 });
 
 export const SUBSCRIBE = Object.freeze({
@@ -26,4 +27,5 @@ export const SUBSCRIBE = Object.freeze({
   webRTCOffer: 'webrtc-offer',
   webRTCAnswer: 'webrtc-answer',
   webRTCLeave: 'webrtc-leave',
+  updateUserStream: 'update-userstream',
 });

--- a/src/hooks/socket/useAuthSocket.ts
+++ b/src/hooks/socket/useAuthSocket.ts
@@ -69,10 +69,6 @@ const useAuthSocketImpl = () => {
       console.log('[on] room-list');
       dispatch(updateAllRooms(data));
     });
-    on(SUBSCRIBE.broadcastRenewedRoomForHomeUsers, ({ data }: { data: GameRoomBroadcastResponse[] }) => {
-      console.log('[on] rooms-refresh');
-      dispatch(updateAllRooms(data));
-    });
   }, []);
 
   return { authorized };

--- a/src/hooks/socket/useGameSocket.ts
+++ b/src/hooks/socket/useGameSocket.ts
@@ -1,6 +1,7 @@
 import { NavigateFunction } from 'react-router-dom';
 
 import { PUBLISH, SUBSCRIBE } from '@constants/socket';
+import useLocalStream from '@hooks/useLocalStream';
 import { useAppDispatch } from '@redux/hooks';
 import { updateRoom } from '@redux/modules/gameRoomSlice';
 
@@ -22,6 +23,7 @@ interface UseGameSocketType {
 const useGameSocket = (): UseGameSocketType => {
   const { on, emit } = socketInstance;
   const dispatch = useAppDispatch();
+  const { initLocalStream } = useLocalStream();
 
   const onBroadcastWholeRooms = () => {
     //
@@ -30,14 +32,14 @@ const useGameSocket = (): UseGameSocketType => {
   const onAnnounceRoomUpdate = () => {
     on(SUBSCRIBE.announceRenewedRoomForRoomMembers, ({ data }: { data: GameRoomDetail }) => {
       console.log('[on] update-room');
-      console.log(data);
       dispatch(updateRoom(data));
     });
   };
 
   const onShowCreatedRoomId = (navigate: NavigateFunction, path: string) => {
-    on(SUBSCRIBE.showCreatedRoomIdForOwner, ({ data }: { data: { roomId: string } }) => {
+    on(SUBSCRIBE.showCreatedRoomIdForOwner, async ({ data }: { data: { roomId: string } }) => {
       console.log('[on] create-room');
+      await initLocalStream();
       navigate(path + data.roomId);
     });
   };

--- a/src/hooks/socket/useGameSocket.ts
+++ b/src/hooks/socket/useGameSocket.ts
@@ -2,17 +2,13 @@ import { NavigateFunction } from 'react-router-dom';
 
 import { PUBLISH, SUBSCRIBE } from '@constants/socket';
 import useLocalStream from '@hooks/useLocalStream';
-import { useAppDispatch } from '@redux/hooks';
-import { updateRoom } from '@redux/modules/gameRoomSlice';
 
-import { GameRoomDetail } from '@customTypes/gameRoomType';
 import { CreateRoomRequest, EnterRoomRequest } from '@customTypes/socketType';
 
 import socketInstance from './socketInstance';
 
 interface UseGameSocketType {
   onBroadcastWholeRooms: () => void;
-  onAnnounceRoomUpdate: () => void;
   onShowCreatedRoomId: (navigate: NavigateFunction, path: string) => void;
   onJoinRoom: () => void;
   emitUserLeaveRoom: () => void;
@@ -22,18 +18,10 @@ interface UseGameSocketType {
 
 const useGameSocket = (): UseGameSocketType => {
   const { on, emit } = socketInstance;
-  const dispatch = useAppDispatch();
   const { initLocalStream } = useLocalStream();
 
   const onBroadcastWholeRooms = () => {
     //
-  };
-
-  const onAnnounceRoomUpdate = () => {
-    on(SUBSCRIBE.announceRenewedRoomForRoomMembers, ({ data }: { data: GameRoomDetail }) => {
-      console.log('[on] update-room');
-      dispatch(updateRoom(data));
-    });
   };
 
   const onShowCreatedRoomId = (navigate: NavigateFunction, path: string) => {
@@ -66,7 +54,6 @@ const useGameSocket = (): UseGameSocketType => {
 
   return {
     onBroadcastWholeRooms,
-    onAnnounceRoomUpdate,
     onShowCreatedRoomId,
     onJoinRoom,
     emitUserLeaveRoom,

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+import { SUBSCRIBE } from '@constants/socket';
+import useWebRTC from '@hooks/useWebRTC';
+import { useAppDispatch } from '@redux/hooks';
+import { updateRoom } from '@redux/modules/gameRoomSlice';
+import { setPlayerList } from '@redux/modules/playerMediaSlice';
+
+import { GameRoomDetail } from '@customTypes/gameRoomType';
+
+import socketInstance from './socketInstance';
+
+const useGameUpdateSocket = () => {
+  const dispatch = useAppDispatch();
+  const { createOffers } = useWebRTC();
+  const { on, off } = socketInstance;
+
+  const onAnnounceRoomUpdate = () => {
+    on(
+      SUBSCRIBE.announceRenewedRoomForRoomMembers,
+      ({ data }: { data: { room: GameRoomDetail; eventUserInfo: { socketId: string; isEnterEvent: boolean } } }) => {
+        dispatch(updateRoom(data.room));
+        dispatch(setPlayerList(data.room.participants));
+        const mySocketId = socketInstance.socketInstance.id;
+        if (mySocketId !== data.eventUserInfo.socketId) {
+          const participantsFilteredMe = data.room.participants.filter(
+            (participant) => participant.socketId !== mySocketId,
+          );
+          participantsFilteredMe.forEach((participant) => {
+            createOffers(participant.socketId);
+          });
+        }
+      },
+    );
+  };
+
+  useEffect(() => {
+    return () => {
+      console.log('[on] update-room');
+      off(SUBSCRIBE.announceRenewedRoomForRoomMembers);
+    };
+  }, []);
+
+  return { onAnnounceRoomUpdate };
+};
+
+export default useGameUpdateSocket;

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -18,7 +18,15 @@ const useGameUpdateSocket = () => {
   const onAnnounceRoomUpdate = () => {
     on(
       SUBSCRIBE.announceRenewedRoomForRoomMembers,
-      ({ data }: { data: { room: GameRoomDetail; eventUserInfo: { socketId: string; isEnterEvent: boolean } } }) => {
+      ({
+        data,
+      }: {
+        data: {
+          room: GameRoomDetail;
+          eventUserInfo: { socketId: string };
+          event: 'enter' | 'leave' | 'leave-force' | 'ready' | 'start';
+        };
+      }) => {
         console.log('[on] update-room');
         dispatch(updateRoom(data.room));
         dispatch(setPlayerList(data.room.participants));

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -19,6 +19,7 @@ const useGameUpdateSocket = () => {
     on(
       SUBSCRIBE.announceRenewedRoomForRoomMembers,
       ({ data }: { data: { room: GameRoomDetail; eventUserInfo: { socketId: string; isEnterEvent: boolean } } }) => {
+        console.log('[on] update-room');
         dispatch(updateRoom(data.room));
         dispatch(setPlayerList(data.room.participants));
         const mySocketId = socketInstance.socketInstance.id;
@@ -36,7 +37,6 @@ const useGameUpdateSocket = () => {
 
   useEffect(() => {
     return () => {
-      console.log('[on] update-room');
       off(SUBSCRIBE.announceRenewedRoomForRoomMembers);
     };
   }, []);

--- a/src/hooks/socket/useStreamUpdateSocket.ts
+++ b/src/hooks/socket/useStreamUpdateSocket.ts
@@ -1,0 +1,53 @@
+import { off } from 'process';
+
+import { PUBLISH, SUBSCRIBE } from '@constants/socket';
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { setPlayerList } from '@redux/modules/playerMediaSlice';
+
+import socketInstance from './socketInstance';
+
+export interface OnUpdateUserStreamProps {
+  socketId: string;
+  audio: boolean;
+  video: boolean;
+}
+
+export interface EmitUpdateUserStreamProps {
+  audio?: boolean;
+  video?: boolean;
+}
+
+const useStreamUpdateSocket = () => {
+  const { on, off, emit } = socketInstance;
+  const dispatch = useAppDispatch();
+  const { userCam, userMic } = useAppSelector((state) => state.userMedia);
+  const { playerList } = useAppSelector((state) => state.playerMedia);
+
+  const emitUpdateUserStream = (values: EmitUpdateUserStreamProps) => {
+    console.log('[emit] update-userstream');
+    emit(PUBLISH.updateUserStream, {
+      data: {
+        video: values?.video ?? userCam,
+        audio: values?.audio ?? userMic,
+      },
+    });
+  };
+
+  const onUpdateUserStream = () => {
+    on(SUBSCRIBE.updateUserStream, ({ data }: { data: OnUpdateUserStreamProps }) => {
+      console.log('[on] update-userstream');
+      const updatedPlayerList = [...playerList].map((player) =>
+        data.socketId === player.socketId ? { ...player, audio: data.audio, video: data.video } : player,
+      );
+      dispatch(setPlayerList(updatedPlayerList));
+    });
+  };
+
+  const offUpdateUserStream = () => {
+    off(SUBSCRIBE.updateUserStream);
+  };
+
+  return { emitUpdateUserStream, onUpdateUserStream, offUpdateUserStream };
+};
+
+export default useStreamUpdateSocket;

--- a/src/hooks/useLocalStream.ts
+++ b/src/hooks/useLocalStream.ts
@@ -1,0 +1,95 @@
+import React, { useRef } from 'react';
+
+import { useAppDispatch } from '@redux/hooks';
+import {
+  ConstraintsType,
+  setLocalDeviceAudio,
+  setLocalDeviceVideo,
+  setUserCam,
+  setUserMic,
+  setUserStream,
+  setUserStreamRef,
+} from '@redux/modules/userMediaSlice';
+
+const useLocalStream = () => {
+  const dispatch = useAppDispatch();
+  const streamRef = useRef<MediaStream>();
+  const userMicPermissionRef = useRef<boolean>(false);
+  const userCamPermissionRef = useRef<boolean>(false);
+
+  const initLocalStream = async () => {
+    await getLocalStream();
+    console.log('[ready] local stream');
+  };
+
+  const destroyLocalStream = (streamRef: React.MutableRefObject<MediaStream | undefined>) => {
+    streamRef?.current?.getTracks().forEach((track) => track.stop());
+    dispatch(setUserStreamRef(streamRef));
+  };
+
+  const getLocalStream = async () => {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const hasCam = devices.some((device) => device.kind === 'videoinput');
+    const hasMic = devices.some((device) => device.kind === 'audioinput');
+    if (!hasCam && !hasMic) {
+      setEmptyLocalStream();
+      return;
+    }
+    await getUserPermission({ video: hasCam, audio: hasMic });
+  };
+
+  const getMyMedia = async (constraints: ConstraintsType) => {
+    try {
+      if (constraints.audio) {
+        constraints.audio = { echoCancellation: true, noiseSuppression: true };
+        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        streamRef.current = stream;
+        dispatch(setUserStream(stream));
+        dispatch(setUserStreamRef(streamRef));
+        setCamDevice(userCamPermissionRef.current);
+        setMicDevice(userMicPermissionRef.current);
+      }
+    } catch (error) {
+      setEmptyLocalStream();
+    }
+  };
+
+  const getDevicePermissionState = async (
+    device: 'camera' | 'microphone',
+    deviceRef: React.MutableRefObject<boolean>,
+  ) => {
+    const devicePermissionName = device as PermissionName;
+    const permission = await navigator.permissions.query({ name: devicePermissionName });
+    const isAccessible = permission && permission.state !== 'denied';
+    deviceRef.current = isAccessible;
+  };
+
+  const getUserPermission = async (constraints: ConstraintsType) => {
+    constraints.audio && getDevicePermissionState('microphone', userMicPermissionRef);
+    constraints.video && getDevicePermissionState('camera', userCamPermissionRef);
+    await getMyMedia({ video: constraints.video, audio: constraints.audio });
+  };
+
+  function setMicDevice(audio: boolean) {
+    dispatch(setLocalDeviceAudio(audio));
+    dispatch(setUserMic(audio));
+  }
+
+  function setCamDevice(video: boolean) {
+    dispatch(setLocalDeviceVideo(video));
+    dispatch(setUserCam(video));
+  }
+
+  function setEmptyLocalStream() {
+    const emptyStream = new MediaStream();
+    streamRef.current = emptyStream;
+    dispatch(setUserStream(emptyStream));
+    dispatch(setUserStreamRef(streamRef));
+    dispatch(setUserCam(false));
+    dispatch(setUserMic(false));
+  }
+
+  return { initLocalStream, destroyLocalStream };
+};
+
+export default useLocalStream;

--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { PUBLISH, SUBSCRIBE } from '@constants/socket';
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { addPlayerPeer, addPlayerStream } from '@redux/modules/playerMediaSlice';
+
+import socketInstance from './socket/socketInstance';
+
+const useWebRTC = () => {
+  const dispatch = useAppDispatch();
+  const { localDevice, userStreamRef } = useAppSelector((state) => state.userMedia);
+  const { playerStreamMap } = useAppSelector((state) => state.playerMedia);
+  const pcsRef = useRef<{ [socketId: string]: RTCPeerConnection }>({});
+  const { on, emit, off } = socketInstance;
+
+  const createPeerConnection = useCallback(async (peerSocketId: string): Promise<any> => {
+    const result = await new Promise((resolve) => {
+      try {
+        const peerConnection = new RTCPeerConnection({
+          iceServers: [
+            {
+              urls: ['stun:stun.l.google.com:19302', 'stun:stun.l.google.com:19302'],
+            },
+          ],
+        });
+        peerConnection.onicecandidate = (e) => {
+          if (e.candidate) {
+            emit(SUBSCRIBE.webRTCIce, {
+              data: {
+                ice: e.candidate,
+                candidateReceiveSocketId: peerSocketId,
+              },
+            });
+          }
+        };
+        if (!userStreamRef?.current) {
+          alert('no selfStream');
+          return;
+        }
+        userStreamRef.current.getTracks().forEach((track) => {
+          userStreamRef.current && peerConnection.addTrack(track, userStreamRef.current);
+        });
+        peerConnection.ontrack = (e) => {
+          dispatch(addPlayerStream({ socketId: peerSocketId, stream: e.streams[0] }));
+          dispatch(addPlayerPeer({ socketId: peerSocketId, peer: peerConnection }));
+        };
+        resolve(peerConnection);
+      } catch (error) {
+        console.log(error);
+        return undefined;
+      }
+    });
+    return result;
+  }, []);
+
+  const createOffers = async (socketId: string) => {
+    if (pcsRef.current[socketId]) {
+      return;
+    }
+    const peerConnection: RTCPeerConnection = await createPeerConnection(socketId);
+    if (!peerConnection) {
+      alert('no peerconnnection');
+      return;
+    }
+    pcsRef.current = { ...pcsRef.current, [socketId]: peerConnection };
+    try {
+      const localSessionDescription = await peerConnection.createOffer({
+        offerToReceiveAudio: localDevice.audio,
+        offerToReceiveVideo: localDevice.video,
+      });
+      await peerConnection.setLocalDescription(new RTCSessionDescription(localSessionDescription));
+      emit(PUBLISH.webRTCOffer, {
+        data: {
+          sessionDescription: localSessionDescription,
+          offerReceiveSocketId: socketId,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    on(
+      SUBSCRIBE.webRTCOffer,
+      async ({
+        data: { sessionDescription, offerSendSocketId },
+      }: {
+        data: { sessionDescription: RTCSessionDescription; offerSendSocketId: string };
+      }) => {
+        const peerconnection = await createPeerConnection(offerSendSocketId);
+        if (!peerconnection) {
+          return;
+        }
+        pcsRef.current = { ...pcsRef.current, [offerSendSocketId]: peerconnection };
+        try {
+          await peerconnection.setRemoteDescription(new RTCSessionDescription(sessionDescription));
+          const localSessionDescription = await peerconnection.createAnswer();
+          await peerconnection.setLocalDescription(new RTCSessionDescription(localSessionDescription));
+          emit(PUBLISH.webRTCAnswer, {
+            data: {
+              sessionDescription: localSessionDescription,
+              answerReceiveSocketId: offerSendSocketId,
+            },
+          });
+        } catch (error) {
+          console.log(error);
+        }
+      },
+    );
+
+    on(
+      SUBSCRIBE.webRTCAnswer,
+      ({
+        data: { sessionDescription, answerSendSocketId },
+      }: {
+        data: { sessionDescription: RTCSessionDescription; answerSendSocketId: string };
+      }) => {
+        const peerconnection: RTCPeerConnection = pcsRef.current[answerSendSocketId];
+        if (!peerconnection) {
+          alert('[on] webrtc-answer - no peerconnection!');
+          return;
+        }
+        (async () => {
+          await peerconnection.setRemoteDescription(new RTCSessionDescription(sessionDescription));
+        })();
+      },
+    );
+
+    on(
+      SUBSCRIBE.webRTCIce,
+      async ({ data: { ice, iceSendSocketId } }: { data: { ice: RTCIceCandidate; iceSendSocketId: string } }) => {
+        const peerconnection: RTCPeerConnection = pcsRef.current[iceSendSocketId];
+        if (!peerconnection) {
+          return;
+        }
+        await peerconnection.addIceCandidate(new RTCIceCandidate(ice));
+      },
+    );
+
+    on(SUBSCRIBE.webRTCLeave, ({ data: { leaverSocketId } }: { data: { leaverSocketId: string } }) => {
+      delete pcsRef.current[leaverSocketId];
+    });
+
+    return () => {
+      off(SUBSCRIBE.webRTCOffer);
+      off(SUBSCRIBE.webRTCAnswer);
+      off(SUBSCRIBE.webRTCIce);
+      off(SUBSCRIBE.webRTCLeave);
+    };
+  }, [playerStreamMap]);
+
+  useEffect(() => {
+    return () => {
+      emit('webrtc-leave');
+      Object.entries(playerStreamMap).forEach((map) => {
+        const socketId = map[0];
+        const stream = map[1];
+        if (!stream || !pcsRef.current[socketId]) {
+          return;
+        }
+        pcsRef.current[socketId].close();
+        delete pcsRef.current[socketId];
+      });
+    };
+  }, []);
+
+  return { createOffers };
+};
+
+export default useWebRTC;

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 
 import { useAuthSocket } from '@hooks/socket/useAuthSocket';
 import useGameSocket from '@hooks/socket/useGameSocket';
+import useLocalStream from '@hooks/useLocalStream';
+import { useAppSelector } from '@redux/hooks';
 
 import Layout from '@components/common/Layout';
 import CamList from '@components/game/CamList';
@@ -13,11 +15,22 @@ import ChatLog from '@components/game/ChatLog';
 const Room = () => {
   const { id } = useParams();
   const { authorized } = useAuthSocket();
+  const { userStreamRef } = useAppSelector((state) => state.userMedia);
+  const { destroyLocalStream } = useLocalStream();
 
   const { emitUserLeaveRoom, emitJoinRoom, onAnnounceRoomUpdate, onJoinRoom } = useGameSocket();
   useEffect(() => {
     return () => emitUserLeaveRoom();
   }, []);
+
+  useEffect(() => {
+    if (userStreamRef) {
+      return () => {
+        destroyLocalStream(userStreamRef);
+        console.log('[destroy] local stream');
+      };
+    }
+  }, [userStreamRef]);
 
   useEffect(() => {
     onAnnounceRoomUpdate();
@@ -47,30 +60,12 @@ const Room = () => {
             <ChatLog />
           </Layout>
         </div>
-        <Layout height={550} width={400}>
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(2,1fr)',
-            }}
-          >
-            <Cam />
-            <Cam />
-            <Cam />
-            <Cam />
-            <Cam />
-            <Cam />
-            {/* <CamList /> */}
-          </div>
+        <Layout width={400} height={500}>
+          <CamList />
         </Layout>
       </div>
     </Layout>
   );
 };
 
-const Cam = styled.div`
-  border: 1px solid white;
-  width: 160px;
-  height: 160px;
-`;
 export default Room;

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { useAuthSocket } from '@hooks/socket/useAuthSocket';
 import useGameSocket from '@hooks/socket/useGameSocket';
+import useGameUpdateSocket from '@hooks/socket/useGameUpdateSocket';
 import useLocalStream from '@hooks/useLocalStream';
 import { useAppSelector } from '@redux/hooks';
 
@@ -17,8 +18,8 @@ const Room = () => {
   const { authorized } = useAuthSocket();
   const { userStreamRef } = useAppSelector((state) => state.userMedia);
   const { destroyLocalStream } = useLocalStream();
-
-  const { emitUserLeaveRoom, emitJoinRoom, onAnnounceRoomUpdate, onJoinRoom } = useGameSocket();
+  const { onAnnounceRoomUpdate } = useGameUpdateSocket();
+  const { emitUserLeaveRoom, emitJoinRoom, onJoinRoom } = useGameSocket();
   useEffect(() => {
     return () => emitUserLeaveRoom();
   }, []);

--- a/src/redux/modules/playerMediaSlice.ts
+++ b/src/redux/modules/playerMediaSlice.ts
@@ -1,0 +1,53 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface WebRTCUser {
+  socketId: string;
+  userId: number;
+  nickname: string;
+  audio?: boolean;
+  video?: boolean;
+}
+
+export interface playerMediaStateType {
+  playerStreamMap: { [socketId: string]: MediaStream };
+  playerPeerMap: { [socketId: string]: RTCPeerConnection };
+  playerList: WebRTCUser[];
+}
+
+const initialState: playerMediaStateType = {
+  playerStreamMap: {},
+  playerPeerMap: {},
+  playerList: [],
+};
+
+const playerMediaSlice = createSlice({
+  name: 'playerMedia',
+  initialState,
+  reducers: {
+    addPlayerStream: (state, action: PayloadAction<{ socketId: string; stream: MediaStream }>) => {
+      const { socketId, stream } = action.payload;
+      state.playerStreamMap = {
+        ...state.playerStreamMap,
+        ...{
+          [socketId]: stream,
+        },
+      };
+    },
+    addPlayerPeer: (state, action: PayloadAction<{ socketId: string; peer: RTCPeerConnection }>) => {
+      const { socketId, peer } = action.payload;
+      state.playerPeerMap = {
+        ...state.playerPeerMap,
+        ...{
+          [socketId]: peer,
+        },
+      };
+    },
+    setPlayerList: (state, action: PayloadAction<WebRTCUser[]>) => {
+      state.playerList = action.payload;
+    },
+  },
+});
+
+export const { addPlayerStream, addPlayerPeer, setPlayerList } = playerMediaSlice.actions;
+
+export default playerMediaSlice;

--- a/src/redux/modules/userMediaSlice.ts
+++ b/src/redux/modules/userMediaSlice.ts
@@ -1,0 +1,54 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface ConstraintsType {
+  video: boolean;
+  audio: any;
+}
+
+export interface UserMediaStateType {
+  userStream: MediaStream;
+  userStreamRef?: React.MutableRefObject<MediaStream | undefined>;
+  userCam: boolean;
+  userMic: boolean;
+  localDevice: ConstraintsType;
+}
+
+const initialState: UserMediaStateType = {
+  userStream: new MediaStream(),
+  userCam: false,
+  userMic: false,
+  localDevice: {
+    video: false,
+    audio: false,
+  },
+};
+
+const userMediaSlice = createSlice({
+  name: 'userMedia',
+  initialState,
+  reducers: {
+    setUserStream: (state, action: PayloadAction<MediaStream>) => {
+      state.userStream = action.payload;
+    },
+    setUserStreamRef: (state, action: PayloadAction<React.MutableRefObject<MediaStream | undefined>>) => {
+      state.userStreamRef = action.payload;
+    },
+    setUserCam: (state, action: PayloadAction<boolean>) => {
+      state.userCam = action.payload;
+    },
+    setUserMic: (state, action: PayloadAction<boolean>) => {
+      state.userMic = action.payload;
+    },
+    setLocalDeviceVideo: (state, action: PayloadAction<boolean>) => {
+      state.localDevice = { ...state.localDevice, video: action.payload };
+    },
+    setLocalDeviceAudio: (state, action: PayloadAction<boolean>) => {
+      state.localDevice = { ...state.localDevice, audio: action.payload };
+    },
+  },
+});
+
+export const { setUserStream, setUserStreamRef, setUserCam, setUserMic, setLocalDeviceVideo, setLocalDeviceAudio } =
+  userMediaSlice.actions;
+
+export default userMediaSlice;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,6 +1,7 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
 import gameRoomSlice from './modules/gameRoomSlice';
+import playerMediaSlice from './modules/playerMediaSlice';
 import userMediaSlice from './modules/userMediaSlice';
 import userSlice from './modules/userSlice';
 
@@ -8,6 +9,7 @@ const rootReducer = combineReducers({
   user: userSlice.reducer,
   gameRoom: gameRoomSlice.reducer,
   userMedia: userMediaSlice.reducer,
+  playerMedia: playerMediaSlice.reducer,
 });
 
 export const store = configureStore({

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,11 +1,13 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
 import gameRoomSlice from './modules/gameRoomSlice';
+import userMediaSlice from './modules/userMediaSlice';
 import userSlice from './modules/userSlice';
 
 const rootReducer = combineReducers({
   user: userSlice.reducer,
   gameRoom: gameRoomSlice.reducer,
+  userMedia: userMediaSlice.reducer,
 });
 
 export const store = configureStore({

--- a/src/types/gameRoomType.ts
+++ b/src/types/gameRoomType.ts
@@ -22,4 +22,7 @@ export interface Participant {
   nickname: string;
   profileImg: string;
   isReady: boolean;
+  socketId: string;
+  audio?: boolean;
+  video?: boolean;
 }


### PR DESCRIPTION
### Issue

- resolves #12 

<br>

### 요약

하나의 방에 있는 사용자들 간의 최소한의 미디어 커뮤니케이션이 가능하도록 기능을 구현한다.

<br>

### 작업 내용

- localMediaStream 처리 추가: 현재 브라우저의 사용자 비디오/오디오 사용
 - 방에서 본인의 미디어스트림을 사용
- WebRTC 흐름 추가
  - 기본적인 `offer`, `answer`, `ice`를 통해 상호간 연결
- 로컬 비디오/오디오를 사용자가 키고 끌 수 있다.
- 본인의 비디오/오디오 변경 정보는 방의 모두에게 공유된다.

<br>

다른사용자가 들어왔을 때 내 sdp를 준다.
![image](https://user-images.githubusercontent.com/76927397/212297720-0715b707-c3cb-4fe6-81d2-8ed808796175.png)



### 웹소켓 이벤트 네임 명세 업데이트

![image](https://user-images.githubusercontent.com/76927397/212020465-462c4e87-69e4-4e2c-83ab-cb451223b77d.png)



### 메모

비록 백엔드를 만들며 구현했으나 실제 백엔드 데브 브랜치 코드와의 동기화를 위해 노력해야한다.

<br>

### 리뷰어에게 할 말

아직  `update-room` 관련 명세 동기화 하나를 해야 하는데 매우 사소한 부분이라 리뷰에는 지장없습니다.
 
리뷰 승인 후 반영하게 되더라도 이해해주세요!

@jn33-dev 
