### PR TITLE
FEAT: 게임방 채팅 구현

### DIFF
--- a/src/components/game/CamList.tsx
+++ b/src/components/game/CamList.tsx
@@ -93,7 +93,7 @@ const CamList = () => {
           </div>
         );
       })}
-      {emptyUserCount !== 0 && [...Array(emptyUserCount)].map((v) => <Cam key={v} nickname={'EMPTY'} />)}
+      {emptyUserCount !== 0 && [...Array(emptyUserCount)].map((v, i) => <Cam key={i} nickname={'EMPTY'} />)}
     </CamListLayout>
   );
 };

--- a/src/components/game/ChatLog.tsx
+++ b/src/components/game/ChatLog.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
 import useChatSocket from '@hooks/socket/useChatSocket';
-import { useAppSelector } from '@redux/hooks';
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { clearChatList } from '@redux/modules/gameRoomSlice';
 
 // TODO: 색상 변경할 것
 interface ChatColorType {
@@ -21,7 +22,14 @@ const ChatColor: ChatColorType = {
 const ChatLog = () => {
   const { chatList } = useAppSelector((state) => state.gameRoom);
   const [chat, setChat] = useState<string>('');
+  const dispatch = useAppDispatch();
   const { emitSendChat } = useChatSocket();
+
+  useEffect(() => {
+    return () => {
+      dispatch(clearChatList());
+    };
+  }, []);
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!chat) {

--- a/src/components/game/ChatLog.tsx
+++ b/src/components/game/ChatLog.tsx
@@ -1,37 +1,92 @@
+import React, { useState } from 'react';
+
 import styled from 'styled-components';
 
+import useChatSocket from '@hooks/socket/useChatSocket';
+import { useAppSelector } from '@redux/hooks';
+
+// TODO: 색상 변경할 것
+interface ChatColorType {
+  notification: string;
+  answer: string;
+  chat: string;
+}
+
+const ChatColor: ChatColorType = {
+  notification: 'yellow',
+  answer: 'green',
+  chat: 'inherit',
+};
+
 const ChatLog = () => {
+  const { chatList } = useAppSelector((state) => state.gameRoom);
+  const [chat, setChat] = useState<string>('');
+  const { emitSendChat } = useChatSocket();
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!chat) {
+      return;
+    }
+    if (e.key === 'Enter') {
+      emitSendChat(chat);
+      setChat('');
+    }
+  };
+
   return (
     <ChatLogLayout>
       <ChatBox>
-        <p>ANSWER 1</p>
-        <p>ANSWER 2</p>
+        {chatList.map((chat, index) => (
+          <Chat chatColor={ChatColor[chat.type]} key={index}>
+            {chat.nickname}: {chat.message}
+          </Chat>
+        ))}
       </ChatBox>
-      <ChatInput placeholder="| TEXT ..." />
+      <ChatInput
+        placeholder="TEXT ..."
+        onKeyDown={handleInputKeyDown}
+        onChange={(e) => setChat(e.target.value)}
+        value={chat}
+      />
     </ChatLogLayout>
   );
 };
 
 const ChatLogLayout = styled.div`
-  height: 92.1%;
-  display: grid;
-  grid-template-rows: 7fr 1fr;
+  height: 100%;
 `;
 
+// TODO: 스크롤 스타일링
 const ChatBox = styled.div`
-  font-size: 24px;
+  display: flex;
+  flex-direction: column-reverse;
+  height: 401px;
+  overflow-y: auto;
+  font-size: 20px;
   color: ${(props) => props.theme.colors.chatBoxFont};
   padding: 20px;
 `;
 
 const ChatInput = styled.input`
   background-color: ${(props) => props.theme.colors.footer};
-  padding-top: 7px;
-  padding-left: 20px;
+  padding: 14px 0 11px 20px;
+  font-size: 18px;
+  width: 100%;
+  color: ${(props) => props.theme.colors.outline};
   ::placeholder {
     color: ${(props) => props.theme.colors.outline};
-    font-size: 24px;
+    opacity: 0.6;
   }
+  :focus {
+    outline: none;
+  }
+`;
+
+// TODO: 폰트 변경할 것
+const Chat = styled.p<{ chatColor: string }>`
+  font-size: 15px;
+  margin-top: 6px;
+  color: ${(props) => props.chatColor};
 `;
 
 export default ChatLog;

--- a/src/hooks/socket/useChatSocket.ts
+++ b/src/hooks/socket/useChatSocket.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+import { PUBLISH, SUBSCRIBE } from '@constants/socket';
+import { useAppDispatch } from '@redux/hooks';
+import { addChat } from '@redux/modules/gameRoomSlice';
+
+import { EventUserInfo } from '@customTypes/socketType';
+
+import socketInstance from './socketInstance';
+
+const useChatSocket = () => {
+  const { on, emit, off } = socketInstance;
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    on(SUBSCRIBE.receiveChat, ({ data }: { data: { message: string; eventUserInfo: EventUserInfo } }) => {
+      dispatch(addChat({ ...data.eventUserInfo, message: data.message, type: 'chat' }));
+    });
+    return () => {
+      off(SUBSCRIBE.receiveChat);
+    };
+  }, []);
+
+  const emitSendChat = (message: string) => {
+    emit(PUBLISH.sendChat, { data: { message } });
+  };
+
+  return { emitSendChat };
+};
+
+export default useChatSocket;

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -3,17 +3,28 @@ import { useEffect } from 'react';
 import { SUBSCRIBE } from '@constants/socket';
 import useWebRTC from '@hooks/useWebRTC';
 import { useAppDispatch } from '@redux/hooks';
-import { updateRoom } from '@redux/modules/gameRoomSlice';
+import { addChat, updateRoom } from '@redux/modules/gameRoomSlice';
 import { setPlayerList } from '@redux/modules/playerMediaSlice';
 
 import { GameRoomDetail } from '@customTypes/gameRoomType';
+import { EventUserInfo } from '@customTypes/socketType';
 
 import socketInstance from './socketInstance';
+
+interface InOutEventMessageType {
+  enter: string;
+  leave: string;
+  'leave-force': string;
+}
 
 const useGameUpdateSocket = () => {
   const dispatch = useAppDispatch();
   const { createOffers } = useWebRTC();
   const { on, off } = socketInstance;
+
+  function isInOutEvent(event: string) {
+    return event === 'enter' || event === 'leave' || event === 'leave-force';
+  }
 
   const onAnnounceRoomUpdate = () => {
     on(
@@ -23,15 +34,32 @@ const useGameUpdateSocket = () => {
       }: {
         data: {
           room: GameRoomDetail;
-          eventUserInfo: { socketId: string };
+          eventUserInfo: EventUserInfo;
           event: 'enter' | 'leave' | 'leave-force' | 'ready' | 'start';
         };
       }) => {
         console.log('[on] update-room');
+        const { nickname, socketId, userId } = data.eventUserInfo;
         dispatch(updateRoom(data.room));
         dispatch(setPlayerList(data.room.participants));
+        if (isInOutEvent(data.event)) {
+          const InOutEventMessageType: InOutEventMessageType = {
+            enter: `'${nickname}'님이 입장하셨습니다.`,
+            leave: `'${nickname}'님이 떠나갔습니다..`,
+            'leave-force': `'${nickname}'님이 퇴장당하셨습니다.`,
+          };
+          dispatch(
+            addChat({
+              nickname: '알림',
+              userId,
+              socketId,
+              message: InOutEventMessageType[data.event as 'enter' | 'leave' | 'leave-force'],
+              type: 'notification',
+            }),
+          );
+        }
         const mySocketId = socketInstance.socketInstance.id;
-        if (mySocketId !== data.eventUserInfo.socketId) {
+        if (mySocketId !== socketId) {
           const participantsFilteredMe = data.room.participants.filter(
             (participant) => participant.socketId !== mySocketId,
           );

--- a/src/redux/modules/gameRoomSlice.ts
+++ b/src/redux/modules/gameRoomSlice.ts
@@ -32,10 +32,13 @@ const gameRoomSlice = createSlice({
     addChat: (state, action: PayloadAction<Chat>) => {
       state.chatList = [action.payload, ...state.chatList];
     },
+    clearChatList: (state) => {
+      state.chatList = [];
+    },
   },
   extraReducers: {},
 });
 
-export const { joinGameRoom, updateAllRooms, updateRoom, addChat } = gameRoomSlice.actions;
+export const { joinGameRoom, updateAllRooms, updateRoom, addChat, clearChatList } = gameRoomSlice.actions;
 
 export default gameRoomSlice;

--- a/src/redux/modules/gameRoomSlice.ts
+++ b/src/redux/modules/gameRoomSlice.ts
@@ -1,17 +1,19 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { GameRoomDetail } from '@customTypes/gameRoomType';
+import { Chat, GameRoomDetail } from '@customTypes/gameRoomType';
 import { GameRoomBroadcastResponse } from '@customTypes/socketType';
 
 // TODO: 게임룸의 상태 정보가 추가될 수 있다. EX) [대기, 게임중, 게임종료] 상태
 interface InitialGameRoomStateType {
   room: GameRoomDetail | null;
   broadcastedRooms: GameRoomBroadcastResponse[];
+  chatList: Chat[];
 }
 
 const initialState: InitialGameRoomStateType = {
   room: null,
   broadcastedRooms: [],
+  chatList: [],
 };
 
 const gameRoomSlice = createSlice({
@@ -27,10 +29,13 @@ const gameRoomSlice = createSlice({
     updateRoom: (state, action) => {
       state.room = action.payload;
     },
+    addChat: (state, action: PayloadAction<Chat>) => {
+      state.chatList = [action.payload, ...state.chatList];
+    },
   },
   extraReducers: {},
 });
 
-export const { joinGameRoom, updateAllRooms, updateRoom } = gameRoomSlice.actions;
+export const { joinGameRoom, updateAllRooms, updateRoom, addChat } = gameRoomSlice.actions;
 
 export default gameRoomSlice;

--- a/src/types/chatType.ts
+++ b/src/types/chatType.ts
@@ -1,8 +1,0 @@
-export interface ChatBaseType {
-  message: string;
-}
-
-export interface Chat extends ChatBaseType {
-  nickname: string;
-  type: 'chat' | 'noti';
-}

--- a/src/types/gameRoomType.ts
+++ b/src/types/gameRoomType.ts
@@ -26,3 +26,14 @@ export interface Participant {
   audio?: boolean;
   video?: boolean;
 }
+
+export interface ChatBaseType {
+  message: string;
+}
+
+export interface Chat extends ChatBaseType {
+  userId: number;
+  socketId: string;
+  nickname: string;
+  type: 'chat' | 'notification' | 'answer';
+}

--- a/src/types/socketType.ts
+++ b/src/types/socketType.ts
@@ -44,3 +44,10 @@ export interface EnterRoomRequest {
 export interface UpdateRoomResponse extends GameRoomBaseInfo, GameRoomPlayDetailInfo {
   participants: Participant[];
 }
+
+export interface EventUserInfo {
+  socketId: string;
+  userId: number;
+  nickname: string;
+  profileImg?: string;
+}


### PR DESCRIPTION
### Issue

- resolves #30 

<br>

### 요약

게임방 참여자 간 채팅 기능 구현

<br>

### 작업 내용

- 유저들의 입장/퇴장 시 채팅에 알림이 식별되도록 기능 추가
- 유저의 채팅이 모두에게 보여지도록 기능 추가
- 엔터 키로 채팅을 등록할 수 있다.
- 채팅이 많아지면 스크롤이 생긴다.
- 방을 나가면 채팅 기록이 모두 초기화 되도록 설정


![image](https://user-images.githubusercontent.com/76927397/212755030-0d3e4d41-b3f1-4541-a270-0fbb1c5b8827.png)



<br>

 
### 알아둬야할 것

- 스크롤 디자인을 추가해야함