### PR TITLE
FEAT: 게임방 상태를 분리하고 소켓 통신을 적용 #13

### DIFF
--- a/src/components/game/GameReady.tsx
+++ b/src/components/game/GameReady.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+
+import useGameUpdateSocket from '@hooks/socket/useGameUpdateSocket';
+import useDebounce from '@hooks/useDebounce';
+
+// TODO: 디자인을 반영해야 한다.
+const GameReady = ({ readyStatus }: { readyStatus: boolean }) => {
+  const [isReady, setIsReady] = useState<boolean>(readyStatus);
+
+  const debouncedReadyState = useDebounce(isReady, 200);
+  const { emitGameReady } = useGameUpdateSocket();
+  useEffect(() => {
+    return () => {
+      emitGameReady();
+    };
+  }, [debouncedReadyState]);
+
+  return (
+    <GameReadyLayout>
+      <button onClick={() => setIsReady(!isReady)}>{isReady ? '레디취소' : '레디하기'}</button>
+    </GameReadyLayout>
+  );
+};
+
+const GameReadyLayout = styled.div``;
+
+export default GameReady;

--- a/src/components/game/GameStart.tsx
+++ b/src/components/game/GameStart.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+import useGameUpdateSocket from '@hooks/socket/useGameUpdateSocket';
+
+// TODO: 디자인을 반영해야 한다.
+const GameStart = ({ isGameReadyToStart }: { isGameReadyToStart: boolean }) => {
+  const { emitGameStart } = useGameUpdateSocket();
+
+  return (
+    <GameStartLayout>
+      <button onClick={emitGameStart} disabled={!isGameReadyToStart}>
+        게임시작
+      </button>
+    </GameStartLayout>
+  );
+};
+
+const GameStartLayout = styled.div``;
+
+export default GameStart;

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -2,15 +2,30 @@ import styled from 'styled-components';
 
 import ImageHolderIcon from '@assets/svg_imageHolderIcon.svg';
 import MicOnIcon from '@assets/svg_micOnIcon.svg';
+import { useAppSelector } from '@redux/hooks';
+
+import GameReady from './GameReady';
+import GameStart from './GameStart';
 
 // TODO: 마이크 꺼졌을때 아이콘 추가하기
 const Presenter = () => {
+  const { user } = useAppSelector((state) => state.user);
+  const { room } = useAppSelector((state) => state.gameRoom);
+  const currentUser = room?.participants.find((participant) => participant.userId === user?.userId);
   return (
     <PresenterLayout>
+      <PresenterCamBox>CAM</PresenterCamBox>
+      <GameReadyBox>
+        {!room?.isGameOn && currentUser?.isHost ? (
+          <GameStart isGameReadyToStart={room?.isGameReadyToStart ?? false} />
+        ) : (
+          <GameReady readyStatus={currentUser?.isReady ?? false} />
+        )}
+      </GameReadyBox>
       <PresenterStatusBox>
         <div>
           <img src={ImageHolderIcon} />
-          <span>닉네임</span>
+          <span>{user?.nickname}</span>
         </div>
         <img className="mic-icon" src={MicOnIcon} />
       </PresenterStatusBox>
@@ -18,7 +33,25 @@ const Presenter = () => {
   );
 };
 
-const PresenterLayout = styled.div``;
+const PresenterLayout = styled.div`
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 100%;
+`;
+
+const PresenterCamBox = styled.div`
+  position: absolute;
+  top: 39px;
+  left: 0;
+`;
+
+// TODO: 디자인 보고 수정
+const GameReadyBox = styled.div`
+  position: absolute;
+  top: 39px;
+  right: 0;
+`;
 
 const PresenterStatusBox = styled.div`
   position: absolute;

--- a/src/constants/socket.ts
+++ b/src/constants/socket.ts
@@ -4,6 +4,8 @@ export const PUBLISH = Object.freeze({
   joinGame: 'enter-room', // 방 입장 요청을 발행한다.
   leaveGame: 'leave-room', // 방 나가기 요청을 발행한다.
   sendChat: 'send-chat', // 채팅 보내기 요청을 발행한다.
+  startGame: 'start',
+  readyGame: 'ready',
 
   // webRTC
   webRTCIce: 'webrtc-ice',

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { SUBSCRIBE } from '@constants/socket';
+import { PUBLISH, SUBSCRIBE } from '@constants/socket';
 import useWebRTC from '@hooks/useWebRTC';
 import { useAppDispatch } from '@redux/hooks';
 import { addChat, updateRoom } from '@redux/modules/gameRoomSlice';
@@ -20,7 +20,7 @@ interface InOutEventMessageType {
 const useGameUpdateSocket = () => {
   const dispatch = useAppDispatch();
   const { createOffers } = useWebRTC();
-  const { on, off } = socketInstance;
+  const { on, off, emit } = socketInstance;
 
   function isInOutEvent(event: string) {
     return event === 'enter' || event === 'leave' || event === 'leave-force';
@@ -71,13 +71,21 @@ const useGameUpdateSocket = () => {
     );
   };
 
+  const emitGameReady = () => {
+    emit(PUBLISH.readyGame);
+  };
+
+  const emitGameStart = () => {
+    emit(PUBLISH.startGame);
+  };
+
   useEffect(() => {
     return () => {
       off(SUBSCRIBE.announceRenewedRoomForRoomMembers);
     };
   }, []);
 
-  return { onAnnounceRoomUpdate };
+  return { onAnnounceRoomUpdate, emitGameReady, emitGameStart };
 };
 
 export default useGameUpdateSocket;

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -39,6 +39,7 @@ const useGameUpdateSocket = () => {
         };
       }) => {
         console.log('[on] update-room');
+        console.log(data);
         const { nickname, socketId, userId } = data.eventUserInfo;
         dispatch(updateRoom(data.room));
         dispatch(setPlayerList(data.room.participants));
@@ -79,13 +80,11 @@ const useGameUpdateSocket = () => {
     emit(PUBLISH.startGame);
   };
 
-  useEffect(() => {
-    return () => {
-      off(SUBSCRIBE.announceRenewedRoomForRoomMembers);
-    };
-  }, []);
+  const offAnnounceRoomUpdate = () => {
+    off(SUBSCRIBE.announceRenewedRoomForRoomMembers);
+  };
 
-  return { onAnnounceRoomUpdate, emitGameReady, emitGameStart };
+  return { onAnnounceRoomUpdate, emitGameReady, emitGameStart, offAnnounceRoomUpdate };
 };
 
 export default useGameUpdateSocket;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -21,10 +21,13 @@ const Room = () => {
   const { authorized } = useAuthSocket();
   const { userStreamRef } = useAppSelector((state) => state.userMedia);
   const { destroyLocalStream } = useLocalStream();
-  const { onAnnounceRoomUpdate } = useGameUpdateSocket();
+  const { onAnnounceRoomUpdate, offAnnounceRoomUpdate } = useGameUpdateSocket();
   const { emitUserLeaveRoom, emitJoinRoom, onJoinRoom } = useGameSocket();
   useEffect(() => {
-    return () => emitUserLeaveRoom();
+    return () => {
+      offAnnounceRoomUpdate();
+      emitUserLeaveRoom();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/types/gameRoomType.ts
+++ b/src/types/gameRoomType.ts
@@ -15,6 +15,7 @@ export interface GameRoomDetail extends GameRoomBaseInfo, GameRoomPlayDetailInfo
   roomId: number;
   isGameOn: boolean;
   participants: Participant[];
+  isGameReadyToStart?: boolean;
 }
 
 export interface Participant {
@@ -25,6 +26,7 @@ export interface Participant {
   socketId: string;
   audio?: boolean;
   video?: boolean;
+  isHost?: boolean;
 }
 
 export interface ChatBaseType {


### PR DESCRIPTION
### Issue

- resolves #13 

<br>

### 요약

게입방에 입장해서 게임을 진행하기 까지의 통신을 구현

<br>

### 작업 내용

- 게임방은 대기/게임 진행중 상태를 가진다.
-  대기 상태의 게임방에서 방장이 아닌 사용자들은 ready를 할 수 있다.
-  방장은 모두가 레디했을 때 게임방을 게임 진행중 상태로 변경시킬 수 있다.
- 레디 버튼은 `debounce`를 적용해 마지막 버튼 클릭의 상태만 서버로 전송되게끔 구현

<br>

### 리뷰어에게 할 말

- 디자인은 일부러 아예 반영안했습니다. 생 div 생 button
- 레디버튼은 레디하기/레디취소로 계속 글씨가 바뀌는데 실제 반영은 마지막에 되는 괴리감이 아직 있음. 추후 한번 클릭 시 일정 시간동안 못 누르는 방식으로 개선

<br>

 
