### PR TITLE
FEAT: 사용자 로컬 미디어스트림 준비 시간 처리를 위한 글로벌 로딩 컴포넌트 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,7 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <div id="modal-root"></div>
+    <div id="loading-root"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/components/common/GlobalLoading.tsx
+++ b/src/components/common/GlobalLoading.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+import styled from 'styled-components';
+
+interface GlobalLoadingProps {
+  isLoading: boolean;
+  children?: React.ReactNode;
+}
+
+// TODO: 디자인 및 필요시 애니메이션 반영 필요
+const GlobalLoading = ({ isLoading, children }: GlobalLoadingProps) => {
+  const portalDiv = document.querySelector('#loading-root');
+  if (!portalDiv) {
+    return null;
+  }
+
+  return (
+    <>
+      {isLoading &&
+        createPortal(
+          <GlobalLoadingLayout>
+            {children}
+            <div>...isLoading</div>
+          </GlobalLoadingLayout>,
+          portalDiv,
+        )}
+    </>
+  );
+};
+
+const GlobalLoadingLayout = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  position: absolute;
+  top: 0;
+  background-color: ${(props) => props.theme.colors.darkGrey2};
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  overflow: hidden;
+  & > div {
+    font-size: 24px;
+    color: ${(props) => props.theme.colors.white};
+    transform: scale(${(props) => props.theme.layout.scale});
+  }
+`;
+
+export default GlobalLoading;

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -30,7 +30,8 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
       round: 1,
     };
     emitCreateRoom(createRoom);
-    onShowCreatedRoomId(navigate, '/room/');
+    onClose();
+    onShowCreatedRoomId(navigate, '/?roomId=');
   };
   return (
     <Modal visible={visible} onClose={onClose} height={700} title="MAKE A ROOM">

--- a/src/hooks/socket/useGameSocket.ts
+++ b/src/hooks/socket/useGameSocket.ts
@@ -1,7 +1,6 @@
 import { NavigateFunction } from 'react-router-dom';
 
 import { PUBLISH, SUBSCRIBE } from '@constants/socket';
-import useLocalStream from '@hooks/useLocalStream';
 
 import { CreateRoomRequest, EnterRoomRequest } from '@customTypes/socketType';
 
@@ -18,7 +17,6 @@ interface UseGameSocketType {
 
 const useGameSocket = (): UseGameSocketType => {
   const { on, emit } = socketInstance;
-  const { initLocalStream } = useLocalStream();
 
   const onBroadcastWholeRooms = () => {
     //
@@ -27,7 +25,6 @@ const useGameSocket = (): UseGameSocketType => {
   const onShowCreatedRoomId = (navigate: NavigateFunction, path: string) => {
     on(SUBSCRIBE.showCreatedRoomIdForOwner, async ({ data }: { data: { roomId: string } }) => {
       console.log('[on] create-room');
-      await initLocalStream();
       navigate(path + data.roomId);
     });
   };

--- a/src/hooks/useLocalStream.ts
+++ b/src/hooks/useLocalStream.ts
@@ -1,10 +1,13 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { useAppDispatch } from '@redux/hooks';
 import {
   ConstraintsType,
+  initMediaStatus,
   setLocalDeviceAudio,
   setLocalDeviceVideo,
+  setMediaDone,
+  setMediaLoading,
   setUserCam,
   setUserMic,
   setUserStream,
@@ -19,15 +22,18 @@ const useLocalStream = () => {
 
   const initLocalStream = async () => {
     await getLocalStream();
+    dispatch(setMediaDone());
     console.log('[ready] local stream');
   };
 
   const destroyLocalStream = (streamRef: React.MutableRefObject<MediaStream | undefined>) => {
     streamRef?.current?.getTracks().forEach((track) => track.stop());
     dispatch(setUserStreamRef(streamRef));
+    dispatch(initMediaStatus());
   };
 
   const getLocalStream = async () => {
+    dispatch(setMediaLoading());
     const devices = await navigator.mediaDevices.enumerateDevices();
     const hasCam = devices.some((device) => device.kind === 'videoinput');
     const hasMic = devices.some((device) => device.kind === 'audioinput');

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import styled from 'styled-components';
 
@@ -18,12 +18,17 @@ import RoomTemplate from '@components/layout/RoomTemplate';
 
 const Room = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
   const { authorized } = useAuthSocket();
-  const { userStreamRef } = useAppSelector((state) => state.userMedia);
+  const { userStreamRef, isMediaSuccess } = useAppSelector((state) => state.userMedia);
   const { destroyLocalStream } = useLocalStream();
   const { onAnnounceRoomUpdate } = useGameUpdateSocket();
   const { emitUserLeaveRoom, emitJoinRoom, onJoinRoom } = useGameSocket();
+
   useEffect(() => {
+    if (!isMediaSuccess) {
+      navigate('/?roomId=' + id);
+    }
     return () => emitUserLeaveRoom();
   }, []);
 
@@ -38,8 +43,9 @@ const Room = () => {
 
   useEffect(() => {
     onAnnounceRoomUpdate();
-    if (authorized) {
-      id && emitJoinRoom({ roomId: parseInt(id, 10) });
+    if (authorized && id) {
+      const intId = parseInt(id, 10);
+      !Number.isNaN(id) && emitJoinRoom({ roomId: parseInt(id, 10) });
       onJoinRoom();
     }
   }, [id, authorized]);

--- a/src/redux/modules/userMediaSlice.ts
+++ b/src/redux/modules/userMediaSlice.ts
@@ -11,6 +11,8 @@ export interface UserMediaStateType {
   userCam: boolean;
   userMic: boolean;
   localDevice: ConstraintsType;
+  isMediaLoading: boolean;
+  isMediaSuccess: boolean;
 }
 
 const initialState: UserMediaStateType = {
@@ -21,6 +23,8 @@ const initialState: UserMediaStateType = {
     video: false,
     audio: false,
   },
+  isMediaLoading: false,
+  isMediaSuccess: false,
 };
 
 const userMediaSlice = createSlice({
@@ -45,10 +49,30 @@ const userMediaSlice = createSlice({
     setLocalDeviceAudio: (state, action: PayloadAction<boolean>) => {
       state.localDevice = { ...state.localDevice, audio: action.payload };
     },
+    setMediaLoading: (state) => {
+      state.isMediaLoading = true;
+    },
+    setMediaDone: (state) => {
+      state.isMediaLoading = false;
+      state.isMediaSuccess = true;
+    },
+    initMediaStatus: (state) => {
+      state.isMediaLoading = false;
+      state.isMediaSuccess = false;
+    },
   },
 });
 
-export const { setUserStream, setUserStreamRef, setUserCam, setUserMic, setLocalDeviceVideo, setLocalDeviceAudio } =
-  userMediaSlice.actions;
+export const {
+  setUserStream,
+  setUserStreamRef,
+  setUserCam,
+  setUserMic,
+  setLocalDeviceVideo,
+  setLocalDeviceAudio,
+  setMediaLoading,
+  setMediaDone,
+  initMediaStatus,
+} = userMediaSlice.actions;
 
 export default userMediaSlice;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,4 @@
+export const getParam = (key: string) => {
+  const params = new URLSearchParams(location.search);
+  return params.get(key) ?? '';
+};


### PR DESCRIPTION
### Issue

- resolves #34 

<br>

### 요약

분리되어있던 로컬 미디어스트림 처리를 중앙화 하고 준비중임을 보여주도록 글로벌 로딩을 적용

<br>

### 작업 내용

방 생성 시, 방 목록에서 방 클릭 시 미디어스트림을 각각 처리하도록 되어있던 부분을 중앙화

<br>

**첫 시도 실패**

>  `Room` 페이지 렌더링 시에 로딩을 적용하고 미디어스트림 불러오기

게임 페이지 로직이나 상태 관리가 매우 복잡하여 게임페이지 렌더링 시 미디어스트림을 불러와 webrtc로 네트워크 연결을 모두 하도록 설정하기에는 변경이 많을 것 같고 

시도해보았으나 `offer`한 쪽에서 상대의 미디어를 잘 가져오지 못하는 문제 발생

아마 이미 가짜 스트림을 가져온 상태에서 업데이트가 안되서 그런걸로 예상되며 해결에 시간이 매우 오래걸릴 것이라 판단함.

<br>

**다른 시도 - 다른페이지이용하기**

- 게임을 생성하던 방목록에서 클릭해 들어가던 `/room/:id` 가 아니라 `/?roomId=:id`로 `navigate` 시켰음.

- 해당 쿼리스트링을 인식시켜 미디어스트림을 업데이트하고 `/room/:id`로 이동시키도록 함

- `/room/:id` 로 직접 접근 시 미디어 스트림 로딩 성공 여부를 판단해 아직 가져오지 않았다면  `/?roomId=:id`로 이동시켜 준비하게 함


<br>

### 이미지 예시


**방 생성**

![Animation](https://user-images.githubusercontent.com/76927397/212996111-6e8d858a-3d1e-4d7f-be3f-e2a5e8b2df47.gif)

<br>


**방 입장**

![Animation](https://user-images.githubusercontent.com/76927397/212996865-6827d001-344c-4595-9db3-ab1b5c509f05.gif)

<br>

**새로고침**

![Animation2](https://user-images.githubusercontent.com/76927397/212997107-9ec983aa-5654-4ea2-8021-d80a9b04c93d.gif)





<br>

### 리뷰어에게 할 말

한 번에 페이지에서 처리하면 좋을 것 같은데 저의 능력으로는 안되겠네여

미디어스트림을 준비하는 페이지나 창이 따로 없는데 바로 게임 페이지에서 이걸 처리하면 서로 얼굴 교환 시 문제가 자꾸 생기더라고요 

<br>


 
