### PR TITLE
FEAT: 소셜 로그인 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "craco-alias": "^3.0.1",
         "json-server": "^0.17.1",
         "react": "^18.2.0",
+        "react-cookie": "^4.1.1",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.6.1",
@@ -3842,6 +3843,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
@@ -14676,6 +14682,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16885,6 +16904,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/universalify": {
@@ -20596,6 +20632,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "@types/eslint": {
       "version": "8.4.10",
@@ -28372,6 +28413,16 @@
         "whatwg-fetch": "^3.6.2"
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -29980,6 +30031,22 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        }
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "craco-alias": "^3.0.1",
     "json-server": "^0.17.1",
     "react": "^18.2.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.6.1",

--- a/server/authenticationHandler.js
+++ b/server/authenticationHandler.js
@@ -4,7 +4,7 @@ const validAuthentication = (req, res) => {
   if (!authorization) {
     return res.status(401).send({ errorMessage: '회원 인증에 실패했습니다.' });
   }
-  return authorization[5];
+  return authorization.split(' ')[1][5];
 };
 
 module.exports = {

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,24 @@ server.use(
   }),
 );
 
+// 카카오 소셜 로그인
+server.get('/api/users/login/kakao', (req, res) => {
+  res.cookie('jwt', 'Bearer token1', { maxAge: 4000 });
+  res.redirect('http://localhost:3000');
+});
+
+// 구글 소셜 로그인
+server.get('/api/users/login/google', (req, res) => {
+  res.cookie('jwt', 'Bearer token2', { maxAge: 4000 });
+  res.redirect('http://localhost:3000');
+});
+
+// 깃헙 소셜 로그인
+server.get('/api/users/login/github', (req, res) => {
+  res.cookie('jwt', 'Bearer token3', { maxAge: 4000 });
+  res.redirect('http://localhost:3000');
+});
+
 // 내 프로필 조회
 server.get('/me', (req, res) => {
   const authenticatedUserId = validAuthentication(req, res);

--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,10 @@ server.get('/api/users/login/github', (req, res) => {
 // 내 프로필 조회
 server.get('/me', (req, res) => {
   const authenticatedUserId = validAuthentication(req, res);
-  return res.jsonp(router.db.__wrapped__.me.find((user) => user.userId == authenticatedUserId));
+  const result = {
+    data: router.db.__wrapped__.me.find((user) => user.userId == authenticatedUserId),
+  };
+  return res.jsonp(result);
 });
 
 server.use(router);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,14 @@
-import { Route, Routes } from 'react-router';
-import { BrowserRouter } from 'react-router-dom';
-
 import { Provider } from 'react-redux';
 import { SingletonHooksContainer } from 'react-singleton-hook';
 import { ThemeProvider } from 'styled-components';
 
-import Main from '@pages/Main';
-import Mypage from '@pages/Mypage';
-import Room from '@pages/Room';
 import store from '@redux/store';
 import { GlobalStyle } from '@styles/GlobalStyle';
 import { theme } from '@styles/theme';
 
 import ToastProvider from '@components/common/ToastProvider';
+
+import Router from './shared/Router';
 
 const App = (): JSX.Element => {
   return (
@@ -21,13 +17,7 @@ const App = (): JSX.Element => {
       <Provider store={store}>
         <SingletonHooksContainer />
         <ToastProvider />
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Main />} />
-            <Route path="/room/:id" element={<Room />} />
-            <Route path="/mypage" element={<Mypage />} />
-          </Routes>
-        </BrowserRouter>
+        <Router />
       </Provider>
     </ThemeProvider>
   );

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -12,10 +12,8 @@ authInstance.interceptors.request.use((config) => {
   return config;
 });
 
-// TODO: 실제 서버 사용시 주석 처리된 return으로 변경 필요
 authInstance.interceptors.response.use((res) => {
-  // return res.data.data;
-  return res.data;
+  return res.data.data;
 });
 
 export { authInstance };

--- a/src/components/common/LoginStatus.tsx
+++ b/src/components/common/LoginStatus.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+import { useAppDispatch } from '@redux/hooks';
+import { __getUserInfo } from '@redux/modules/userSlice';
+import { getCookie } from '@utils/getCookie';
+
+const LoginStatus = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    getCookie('jwt') && sessionStorage.setItem('accessToken', getCookie('jwt'));
+
+    dispatch(__getUserInfo());
+  }, []);
+  return <></>;
+};
+
+export default LoginStatus;

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -98,6 +98,7 @@ const InputBox = styled.div`
 `;
 
 const CreateRoomButton = styled.button`
+  cursor: pointer;
   font-family: inherit;
   font-size: 24px;
   color: ${(props) => props.theme.colors.ivory1};

--- a/src/components/home/LoginModal.tsx
+++ b/src/components/home/LoginModal.tsx
@@ -3,10 +3,9 @@ import styled from 'styled-components';
 import Modal from '@components/common/Modal';
 
 const LoginModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
-  // const KAKAO_AUTH_URL = process.env.REACT_APP_KAKAO_AUTH_URL;
-  const KAKAO_AUTH_URL = `http://localhost:3001/api/users/login/kakao`;
-  const GOOGLE_AUTH_URL = `http://localhost:3001/api/users/login/google`;
-  const GITHUB_AUTH_URL = `http://localhost:3001/api/users/login/github`;
+  const KAKAO_AUTH_URL = process.env.REACT_APP_API_ENDPOINT + '/api/users/login/kakao';
+  const GOOGLE_AUTH_URL = process.env.REACT_APP_API_ENDPOINT + '/api/users/login/google';
+  const GITHUB_AUTH_URL = process.env.REACT_APP_API_ENDPOINT + '/api/users/login/github';
 
   const handleLoginKakaoButtonClick = () => {
     KAKAO_AUTH_URL && (window.location.href = KAKAO_AUTH_URL);

--- a/src/components/home/LoginModal.tsx
+++ b/src/components/home/LoginModal.tsx
@@ -3,12 +3,29 @@ import styled from 'styled-components';
 import Modal from '@components/common/Modal';
 
 const LoginModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
+  // const KAKAO_AUTH_URL = process.env.REACT_APP_KAKAO_AUTH_URL;
+  const KAKAO_AUTH_URL = `http://localhost:3001/api/users/login/kakao`;
+  const GOOGLE_AUTH_URL = `http://localhost:3001/api/users/login/google`;
+  const GITHUB_AUTH_URL = `http://localhost:3001/api/users/login/github`;
+
+  const handleLoginKakaoButtonClick = () => {
+    KAKAO_AUTH_URL && (window.location.href = KAKAO_AUTH_URL);
+  };
+
+  const handleLoginGoogleButtonClick = () => {
+    GOOGLE_AUTH_URL && (window.location.href = GOOGLE_AUTH_URL);
+  };
+
+  const handleLoginGithubButtonClick = () => {
+    GITHUB_AUTH_URL && (window.location.href = GITHUB_AUTH_URL);
+  };
+
   return (
     <Modal visible={visible} onClose={onClose} title="LOGIN">
       <LoginModalLayout>
-        <LoginButton>카카오 로그인</LoginButton>
-        <LoginButton>구글 로그인</LoginButton>
-        <LoginButton>깃허브</LoginButton>
+        <LoginButton onClick={() => handleLoginKakaoButtonClick()}>카카오 로그인</LoginButton>
+        <LoginButton onClick={() => handleLoginGoogleButtonClick()}>구글 로그인</LoginButton>
+        <LoginButton onClick={() => handleLoginGithubButtonClick()}>깃허브</LoginButton>
       </LoginModalLayout>
     </Modal>
   );
@@ -24,6 +41,7 @@ const LoginModalLayout = styled.div`
 `;
 
 const LoginButton = styled.button`
+  cursor: pointer;
   font-family: ${(props) => props.theme.font.korean};
   font-size: 24px;
   color: ${(props) => props.theme.colors.ivory1};

--- a/src/components/home/ReportBugModal.tsx
+++ b/src/components/home/ReportBugModal.tsx
@@ -71,6 +71,7 @@ const ButtonBox = styled.div`
   grid-template-columns: 1fr 1fr;
   margin-top: 20px;
   button {
+    cursor: pointer;
     font-family: inherit;
     font-size: 24px;
     color: ${(props) => props.theme.colors.ivory1};

--- a/src/components/home/UserInfo.tsx
+++ b/src/components/home/UserInfo.tsx
@@ -2,11 +2,17 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
+import { useAppSelector } from '@redux/hooks';
+
 import EditProfileModal from '@components/mypage/EditProfileModal';
 
 import CreateGameModal from './CreateGameModal';
+import LoginModal from './LoginModal';
 
 const UserInfo = ({ mypage }: { mypage?: boolean }) => {
+  const isLogined = useAppSelector((state) => state.user.isLogined);
+
+  const [loginModalVisible, setLoginModalVisible] = useState<boolean>(false);
   const [createGameModalVisible, setCreateGameModalVisible] = useState<boolean>(false);
   const [EditProfileModalVisible, setEditProfileModalVisible] = useState<boolean>(false);
 
@@ -15,15 +21,27 @@ const UserInfo = ({ mypage }: { mypage?: boolean }) => {
       <ProfileBox>
         <UserImageBox></UserImageBox>
         <UserStatusBox>
-          <span className="nickname">닉네임</span>
-          <span>|</span>
-          <span>10TH</span>
+          {!isLogined ? (
+            <span>로그인이 필요한 서비스입니다.</span>
+          ) : (
+            <>
+              <span className="nickname">닉네임</span>
+              <span>|</span>
+              <span>10TH</span>
+            </>
+          )}
         </UserStatusBox>
       </ProfileBox>
+      {loginModalVisible && <LoginModal visible={loginModalVisible} onClose={() => setLoginModalVisible(false)} />}
+
       {createGameModalVisible && (
         <CreateGameModal visible={createGameModalVisible} onClose={() => setCreateGameModalVisible(false)} />
       )}
-      {!mypage && <MakeRoomButton onClick={() => setCreateGameModalVisible(true)}>게임방 만들기</MakeRoomButton>}
+      {!mypage && (
+        <MakeRoomButton onClick={() => (!isLogined ? setLoginModalVisible(true) : setCreateGameModalVisible(true))}>
+          게임방 만들기
+        </MakeRoomButton>
+      )}
 
       {EditProfileModalVisible && (
         <EditProfileModal visible={EditProfileModalVisible} onClose={() => setEditProfileModalVisible(false)} />
@@ -72,13 +90,16 @@ const UserStatusBox = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-
+  span {
+    font-family: ${(props) => props.theme.font.korean};
+  }
   .nickname {
     font-family: ${(props) => props.theme.font.korean};
   }
 `;
 
 const MakeRoomButton = styled.button`
+  cursor: pointer;
   font-family: ${(props) => props.theme.font.korean};
   font-size: 24px;
 `;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,9 +1,15 @@
+import { useNavigate } from 'react-router-dom';
+
 import styled from 'styled-components';
 
 const Header = ({ page, children }: { page?: string; children?: React.ReactNode }) => {
+  const navigate = useNavigate();
+
   return (
     <HeaderLayout>
-      <LogoBox page={page}>LOG0</LogoBox>
+      <LogoBox page={page} onClick={() => page !== 'ROOM' && navigate('/')}>
+        LOG0
+      </LogoBox>
       {children}
     </HeaderLayout>
   );
@@ -18,6 +24,7 @@ const HeaderLayout = styled.div`
 `;
 
 const LogoBox = styled.div<{ page?: string }>`
+  cursor: pointer;
   position: relative;
   color: ${(props) => props.theme.colors.ivory2};
   font-size: 24px;

--- a/src/components/layout/MainTemplate.tsx
+++ b/src/components/layout/MainTemplate.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import styled from 'styled-components';
 
-import GameResultModal from '@components/game/GameResultModal';
-import EnterPrivateRoomModal from '@components/home/EnterPrivateRoomModal';
+import { useAppSelector } from '@redux/hooks';
+
 import LoginModal from '@components/home/LoginModal';
 import ReportBugModal from '@components/home/ReportBugModal';
 
@@ -11,33 +12,30 @@ import Footer from './Footer';
 import Header from './Header';
 import PageContainer from './PageContainer';
 
-// TODO: 방 참가하기 버튼에 비밀방 참가하기 모달을 연결한다.
-// TODO: 게임 결과창 모달을 필요한 컴포넌트에 연결한다.
 const MainTemplate = ({ children }: { children: React.ReactNode }) => {
+  const isLogined = useAppSelector((state) => state.user.isLogined);
+
+  const navigate = useNavigate();
+
   const [loginModalVisible, setLoginModalVisible] = useState<boolean>(false);
-  // const [enterPrivateRoomModalVisible, setEnterPrivateRoomModalVisible] = useState<boolean>(false);
   const [reportBugModalVisible, setReportBugModalVisible] = useState<boolean>(false);
-  const [gameResultModalVisible, setgameResultModalVisible] = useState<boolean>(false);
 
   return (
     <PageContainer>
       <Header>
         {loginModalVisible && <LoginModal visible={loginModalVisible} onClose={() => setLoginModalVisible(false)} />}
-        <LoginButton onClick={() => setLoginModalVisible(true)}>LOGIN</LoginButton>
-        {/* {enterPrivateRoomModalVisible && (
-          <EnterPrivateRoomModal visible={enterPrivateRoomModalVisible} onClose={() => setEnterPrivateRoomModalVisible(false)} />
+        {!isLogined ? (
+          <LoginButton onClick={() => setLoginModalVisible(true)}>LOGIN</LoginButton>
+        ) : (
+          <LoginButton onClick={() => navigate('/mypage')}>MYPAGE</LoginButton>
         )}
-        <LoginButton onClick={() => setEnterPrivateRoomModalVisible(true)}>LOGIN</LoginButton> */}
       </Header>
       <MainContentsBox>{children}</MainContentsBox>
       <Footer>
         <FooterBox>
           <button></button>
           <button></button>
-          {gameResultModalVisible && (
-            <GameResultModal visible={gameResultModalVisible} onClose={() => setgameResultModalVisible(false)} />
-          )}
-          <button onClick={() => setgameResultModalVisible(true)}>결과</button>
+          <button></button>
           {reportBugModalVisible && (
             <ReportBugModal visible={reportBugModalVisible} onClose={() => setReportBugModalVisible(false)} />
           )}
@@ -49,6 +47,7 @@ const MainTemplate = ({ children }: { children: React.ReactNode }) => {
 };
 
 const LoginButton = styled.button`
+  cursor: pointer;
   font-size: 24px;
   margin-right: 150px;
 `;

--- a/src/components/layout/MainTemplate.tsx
+++ b/src/components/layout/MainTemplate.tsx
@@ -4,9 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { useAppSelector } from '@redux/hooks';
+
 import Toast from '@components/common/ToastProvider';
-import GameResultModal from '@components/game/GameResultModal';
-import EnterPrivateRoomModal from '@components/home/EnterPrivateRoomModal';
 import LoginModal from '@components/home/LoginModal';
 import ReportBugModal from '@components/home/ReportBugModal';
 

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,8 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
+import { Cookies } from 'react-cookie';
 import styled from 'styled-components';
 
+import { useAppDispatch } from '@redux/hooks';
+import { __getUserInfo } from '@redux/modules/userSlice';
+
 const PageContainer = ({ children }: { children: React.ReactNode }) => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const cookies = new Cookies();
+
+    const getCookie = (name: string) => {
+      return cookies.get(name);
+    };
+
+    getCookie('jwt') && sessionStorage.setItem('accessToken', getCookie('jwt'));
+
+    sessionStorage.getItem('accessToken') && dispatch(__getUserInfo());
+  }, []);
+
   return (
     <ContainerLayout>
       <ContainerInnerBox>{children}</ContainerInnerBox>

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,26 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { Cookies } from 'react-cookie';
 import styled from 'styled-components';
 
-import { useAppDispatch } from '@redux/hooks';
-import { __getUserInfo } from '@redux/modules/userSlice';
-
 const PageContainer = ({ children }: { children: React.ReactNode }) => {
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    const cookies = new Cookies();
-
-    const getCookie = (name: string) => {
-      return cookies.get(name);
-    };
-
-    getCookie('jwt') && sessionStorage.setItem('accessToken', getCookie('jwt'));
-
-    sessionStorage.getItem('accessToken') && dispatch(__getUserInfo());
-  }, []);
-
   return (
     <ContainerLayout>
       <ContainerInnerBox>{children}</ContainerInnerBox>

--- a/src/components/layout/RoomTemplate.tsx
+++ b/src/components/layout/RoomTemplate.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import styled from 'styled-components';
 
@@ -13,6 +14,8 @@ import Header from './Header';
 import PageContainer from './PageContainer';
 
 const RoomTemplate = ({ children }: { children: React.ReactNode }) => {
+  const navigate = useNavigate();
+
   const [GameRuleModalVisible, setGameRuleModalVisible] = useState<boolean>(false);
   return (
     <PageContainer>
@@ -28,7 +31,7 @@ const RoomTemplate = ({ children }: { children: React.ReactNode }) => {
             <CamButton />
             <MicButton />
           </MediaControlBox>
-          <LeaveButton>나가기</LeaveButton>
+          <LeaveButton onClick={() => navigate('/')}>나가기</LeaveButton>
         </FooterBox>
       </Footer>
     </PageContainer>

--- a/src/components/mypage/EditProfileModal.tsx
+++ b/src/components/mypage/EditProfileModal.tsx
@@ -47,6 +47,7 @@ const InputBox = styled.div`
 `;
 
 const EditProfileButton = styled.button`
+  cursor: pointer;
   font-family: inherit;
   font-size: 24px;
   color: ${(props) => props.theme.colors.ivory1};

--- a/src/hooks/socket/socketInstance.ts
+++ b/src/hooks/socket/socketInstance.ts
@@ -1,6 +1,6 @@
 import { io, Socket } from 'socket.io-client';
 
-const socketInstance: Socket = io(process.env.REACT_APP_API_ENDPOINT || 'http://localhost:8080');
+const socketInstance: Socket = io(process.env.REACT_APP_API_SOCKET || 'http://localhost:8080');
 
 const on = (event: string, callback: (...args: any[]) => void) => {
   socketInstance.on(event, callback);

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,8 +1,4 @@
-import { useEffect } from 'react';
-
 import { useAuthSocket } from '@hooks/socket/useAuthSocket';
-import { useAppDispatch } from '@redux/hooks';
-import { __getUserInfo } from '@redux/modules/userSlice';
 
 import RoomList from '@components/home/RoomList';
 import UserInfo from '@components/home/UserInfo';
@@ -10,13 +6,6 @@ import ContentContainer from '@components/layout/ContentContainer';
 import MainTemplate from '@components/layout/MainTemplate';
 
 const Main = () => {
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    sessionStorage.setItem('accessToken', 'token1');
-    dispatch(__getUserInfo());
-  }, []);
-
   useAuthSocket();
   return (
     <MainTemplate>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import useErrorSocket from '@hooks/socket/useErrorSocket';
 import { useAppDispatch } from '@redux/hooks';
 import { logout } from '@redux/modules/userSlice';
-import { __getUserInfo } from '@redux/modules/userSlice';
 
 import RoomList from '@components/home/RoomList';
 import UserInfo from '@components/home/UserInfo';
@@ -17,7 +16,7 @@ const Main = () => {
   useEffect(() => {
     onError([{ target: 'status', value: 403, callback: () => dispatch(logout()) }]);
   }, []);
- 
+
   return (
     <MainTemplate>
       <ContentContainer title="SCORE" lights={true}>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,9 +1,14 @@
+import { useAppSelector } from '@redux/hooks';
+
 import UserInfo from '@components/home/UserInfo';
 import ContentContainer from '@components/layout/ContentContainer';
 import MyPageTemplate from '@components/layout/MyPageTemplate';
 import Keyword from '@components/mypage/Keyword';
 
 const Mypage = () => {
+  const isLogined = useAppSelector((state) => state.user.isLogined);
+
+  !isLogined && window.location.replace('/');
   return (
     <MyPageTemplate>
       <ContentContainer title="SCORE" lights={true}>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,12 +1,10 @@
-import { useAppSelector } from '@redux/hooks';
-
 import UserInfo from '@components/home/UserInfo';
 import ContentContainer from '@components/layout/ContentContainer';
 import MyPageTemplate from '@components/layout/MyPageTemplate';
 import Keyword from '@components/mypage/Keyword';
 
 const Mypage = () => {
-  const isLogined = useAppSelector((state) => state.user.isLogined);
+  const isLogined = sessionStorage.getItem('accessToken');
 
   !isLogined && window.location.replace('/');
   return (

--- a/src/redux/modules/userSlice.ts
+++ b/src/redux/modules/userSlice.ts
@@ -1,5 +1,3 @@
-import { stat } from 'fs';
-
 import userApi from '@apis/userApi';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
@@ -44,6 +42,9 @@ const userSlice = createSlice({
     builder.addCase(__getUserInfo.fulfilled, (state, action) => {
       state.isLogined = true;
       state.user = action.payload;
+    });
+    builder.addCase(__getUserInfo.rejected, (state) => {
+      state.isLogined = false;
     });
   },
 });

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -1,0 +1,23 @@
+import { Route, Routes } from 'react-router';
+import { BrowserRouter } from 'react-router-dom';
+
+import Main from '@pages/Main';
+import Mypage from '@pages/Mypage';
+import Room from '@pages/Room';
+
+import LoginStatus from '@components/common/LoginStatus';
+
+const Router = () => {
+  return (
+    <BrowserRouter>
+      <LoginStatus />
+      <Routes>
+        <Route path="/" element={<Main />} />
+        <Route path="/room/:id" element={<Room />} />
+        <Route path="/mypage" element={<Mypage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+export default Router;

--- a/src/utils/getCookie.ts
+++ b/src/utils/getCookie.ts
@@ -1,0 +1,7 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};


### PR DESCRIPTION
### Issue

- resolves #10

<br>

### 요약

소셜 로그인 기능 구현 및 비인증 상태 레이아웃 추가

<br>

### 작업 내용

 - 소셜 로그인 버튼 클릭 시 로그인 페이지로 이동
 - 쿠키 감지, 토큰 저장, 회원정보 조회
 - 스토어에 유저 정보 저장
 - 비인증 상태 레이아웃 추가
 - 버튼 cursor pointer로 변경

<br>

### 리뷰어에게 할 말

게임 페이지는 setUser reducer가 지워지기 전이라 인증 상태에서도 처음 페이지에 들어갔을때 비인증으로 인식해 메인페이지로 이동되는 문제가 있어 관련 부분 수정하시게 되면 추가 부탁드립니다! 

<br>

### 추가 사항

- footer 부분 버튼에 cursor가 바뀌지 않는 문제가 있어 다음에 수정할 예정
- 회원정보 조회 시 로딩 페이지 넣으려고 한건 조회가 엄청 빨라서 안넣었어용..!

 
