### PR TITLE
FEAT: 게임만들기 입력 제한/글자 수 잘리는 부분 애니메이션 추가

### DIFF
--- a/src/components/game/CamUserStatus.tsx
+++ b/src/components/game/CamUserStatus.tsx
@@ -35,7 +35,7 @@ const CamUserStatus = ({ nickname, isMicOn, size = 'sub' }: CamUserStatusProps) 
     <CamUserStatusLayout customStyles={CamStatusStyles[size]}>
       <div>
         <PlayerImageHolder size={size}></PlayerImageHolder>
-        <NicknameText>{nickname.length > 7 ? <div>nickname</div> : nickname}</NicknameText>
+        <NicknameText>{nickname.length > 7 ? <div>{nickname}</div> : nickname}</NicknameText>
       </div>
       <div>
         <img

--- a/src/components/game/CamUserStatus.tsx
+++ b/src/components/game/CamUserStatus.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import smallMicOffIcon from '@assets/svg_smallMicOffIcon.svg';
 import smallMicOnIcon from '@assets/svg_smallMicOnIcon.svg';
@@ -35,7 +35,7 @@ const CamUserStatus = ({ nickname, isMicOn, size = 'sub' }: CamUserStatusProps) 
     <CamUserStatusLayout customStyles={CamStatusStyles[size]}>
       <div>
         <PlayerImageHolder size={size}></PlayerImageHolder>
-        <NicknameText>{nickname}</NicknameText>
+        <NicknameText>{nickname.length > 7 ? <div>nickname</div> : nickname}</NicknameText>
       </div>
       <div>
         <img
@@ -69,9 +69,32 @@ const CamUserStatusLayout = styled.div<{ customStyles: CamStatusStylesProps }>`
   }
 `;
 
+const nicknameAnimation = keyframes`
+  from {
+    -moz-transform: translateX(10%);
+    -webkit-transform: translateX(10%);
+    transform: translateX(10%);
+  }
+  to {
+    -moz-transform: translateX(-200%);
+    -webkit-transform: translateX(-200%);
+    transform: translateX(-200%);
+  }
+`;
+
 const NicknameText = styled.span`
   font-size: 12px;
   color: ${(props) => props.theme.colors.lightGrey3};
+  width: 80px;
+  white-space: nowrap;
+  display: block;
+  overflow: hidden;
+
+  div {
+    -moz-animation: ${nicknameAnimation} 7s linear infinite;
+    -webkit-animation: ${nicknameAnimation} 7s linear infinite;
+    animation: ${nicknameAnimation} 7s linear infinite;
+  }
 `;
 
 export default CamUserStatus;

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 
 import lockIcon from '@assets/svg_lockIcon.svg';
-import { PARTICIPANTS_OPTIONS } from '@constants/options';
+import { COUNT_OPTIONS, PARTICIPANTS_OPTIONS } from '@constants/options';
 import useGameSocket from '@hooks/socket/useGameSocket';
 
 import Button from '@components/common/Button';
@@ -31,9 +31,9 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
     const createRoom: CreateRoomRequest = {
       roomTitle,
       maxCount,
-      discussionTime: Number(time.split(':')[0]) * 1000,
-      readyTime: Number(time.split(':')[1]) * 1000,
-      speechTime: Number(time.split(':')[2]) * 1000,
+      readyTime: Number(time.split(':')[0]) * 1000,
+      speechTime: Number(time.split(':')[1]) * 1000,
+      discussionTime: Number(time.split(':')[2]) * 1000,
       round: 1,
       roomPassword: Number(roomPassword),
       isSecretRoom,
@@ -73,8 +73,8 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
         <InputContainer label="인원">
           <Selection options={PARTICIPANTS_OPTIONS} setValue={setMaxCount} />
         </InputContainer>
-        <InputContainer label="카운트">
-          <Input type="text" value={time} onChange={(e) => setTime(e.target.value)} />
+        <InputContainer label="카운트(발표/준비/토론)">
+          <Selection options={COUNT_OPTIONS} setValue={setTime} />
         </InputContainer>
         <CreateRoomButton onClick={handleCreateGameButtonClick}>생성하기</CreateRoomButton>
       </CreateGameModalLayout>

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -62,7 +62,12 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
         </InputContainer>
         {showPasswordInput && (
           <InputContainer label="비밀번호">
-            <Input type="text" value={roomPassword} onChange={(e) => setRoomPassword(e.target.value)} />
+            <Input
+              type="text"
+              value={roomPassword}
+              onChange={(e) => setRoomPassword(e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1'))}
+              maxLength={4}
+            />
           </InputContainer>
         )}
         <InputContainer label="인원">

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -17,16 +17,16 @@ import { CreateRoomRequest } from '@customTypes/socketType';
 
 // TODO: 모든 input을 추가하고 유효성 검사를 수행하여 방을 생성할 수 있어야 한다.
 const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
-  const [showPasswordInput, setShowPasswordInput] = useState<boolean>(false);
   const [roomTitle, setRoomTitle] = useState<string>('');
   const [maxCount, setMaxCount] = useState<number>(2);
   const [time, setTime] = useState<string>('30:30:60');
-  const [roomPassword, setRoomPassword] = useState<string>('');
+  const [roomPassword, setRoomPassword] = useState<string | undefined>();
+  const [isSecretRoom, setIsSecretRoom] = useState<boolean>(false);
   const { onShowCreatedRoomId, emitCreateRoom } = useGameSocket();
   const navigate = useNavigate();
 
   const handleCreateGameButtonClick = () => {
-    if (!roomTitle || maxCount < 2 || maxCount > 6) {
+    if (!roomTitle || maxCount < 2 || maxCount > 6 || (isSecretRoom && String(roomPassword)?.length !== 4)) {
       return;
     }
     const createRoom: CreateRoomRequest = {
@@ -37,7 +37,7 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
       speechTime: Number(time.split(':')[2]) * 1000,
       round: 1,
       roomPassword: Number(roomPassword),
-      isSecretRoom: true,
+      isSecretRoom,
     };
     emitCreateRoom(createRoom);
     onClose();
@@ -56,12 +56,12 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
               onChange={(e) => setRoomTitle(e.target.value)}
               maxLength={12}
             />
-            <PasswordButton onClick={() => setShowPasswordInput((prev) => !prev)}>
+            <PasswordButton onClick={() => setIsSecretRoom((prev) => !prev)}>
               <img src={lockIcon} />
             </PasswordButton>
           </TitleInputBox>
         </InputContainer>
-        {showPasswordInput && (
+        {isSecretRoom && (
           <InputContainer label="비밀번호">
             <Input
               type="text"

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -54,6 +54,7 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
               type="text"
               value={roomTitle}
               onChange={(e) => setRoomTitle(e.target.value)}
+              maxLength={12}
             />
             <PasswordButton onClick={() => setShowPasswordInput((prev) => !prev)}>
               <img src={lockIcon} />

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -15,9 +15,8 @@ import Selection from '@components/common/Selection';
 
 import { CreateRoomRequest } from '@customTypes/socketType';
 
-// TODO: 모든 input을 추가하고 유효성 검사를 수행하여 방을 생성할 수 있어야 한다.
 const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
-  const [roomTitle, setRoomTitle] = useState<string>('');
+  const [roomTitle, setRoomTitle] = useState<string>('가치마인드 한 판 해요');
   const [maxCount, setMaxCount] = useState<number>(2);
   const [time, setTime] = useState<string>('30:30:60');
   const [roomPassword, setRoomPassword] = useState<string | undefined>();

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -19,7 +19,7 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
   const [roomTitle, setRoomTitle] = useState<string>('가치마인드 한 판 해요');
   const [maxCount, setMaxCount] = useState<number>(2);
   const [time, setTime] = useState<string>('30:30:60');
-  const [roomPassword, setRoomPassword] = useState<string | undefined>();
+  const [roomPassword, setRoomPassword] = useState<string>('');
   const [isSecretRoom, setIsSecretRoom] = useState<boolean>(false);
   const { onShowCreatedRoomId, emitCreateRoom } = useGameSocket();
   const navigate = useNavigate();
@@ -35,7 +35,7 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
       speechTime: Number(time.split(':')[1]) * 1000,
       discussionTime: Number(time.split(':')[2]) * 1000,
       round: 1,
-      roomPassword: Number(roomPassword),
+      roomPassword: isSecretRoom ? Number(roomPassword) : 1111,
       isSecretRoom,
     };
     emitCreateRoom(createRoom);

--- a/src/components/home/RoomCard.tsx
+++ b/src/components/home/RoomCard.tsx
@@ -47,7 +47,7 @@ const RoomCardMainBox = styled.div`
     width: 86px;
     height: 86px;
     margin-top: 25px;
-    margin-left: 25px;
+    margin-left: -10px;
   }
 `;
 

--- a/src/components/home/RoomList.tsx
+++ b/src/components/home/RoomList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import enterRoomIcon from '@assets/svg_enterRoomIcon.svg';
 import privateRoomIcon from '@assets/svg_privateRoomIcon.svg';
@@ -88,7 +88,15 @@ const RoomList = () => {
           .map((room) => (
             <RoomCard key={room.roomId}>
               <CardContentsBox>
-                <Title>{room.roomTitle}</Title>
+                <Title>
+                  {room.roomTitle.length > 6 ? (
+                    <div>
+                      <text>{room.roomTitle}</text>
+                    </div>
+                  ) : (
+                    room.roomTitle
+                  )}
+                </Title>
                 <Participants>
                   참여인원: {room.participants.toString()}/{room.maxCount}
                 </Participants>
@@ -135,9 +143,21 @@ const CardContentsBox = styled.div`
   flex-direction: column;
 `;
 
+const titleAnimation = keyframes`
+  from {
+    -moz-transform: translateX(5%);
+    -webkit-transform: translateX(5%);
+    transform: translateX(5%);
+  }
+  to {
+    -moz-transform: translateX(-105%);
+    -webkit-transform: translateX(-105%);
+    transform: translateX(-105%);
+  }
+`;
+
 const Title = styled.span`
   background-image: linear-gradient(0deg, rgba(121, 121, 121, 0.5) 50%, ${(props) => props.theme.colors.ivory2} 50%);
-  background-size: 100%;
   background-clip: text;
   -webkit-text-stroke: 1px ${(props) => props.theme.colors.darkGrey4};
   -webkit-background-clip: text;
@@ -145,6 +165,27 @@ const Title = styled.span`
   font-family: inherit;
   font-size: 20px;
   line-height: 150%;
+  width: 130px;
+  white-space: nowrap;
+  display: block;
+  overflow: hidden;
+
+  div {
+    -moz-animation: ${titleAnimation} 7s linear infinite;
+    -webkit-animation: ${titleAnimation} 7s linear infinite;
+    animation: ${titleAnimation} 7s linear infinite;
+    text {
+      background-image: linear-gradient(
+        0deg,
+        rgba(121, 121, 121, 0.5) 50%,
+        ${(props) => props.theme.colors.ivory2} 50%
+      );
+      background-clip: text;
+      -webkit-text-stroke: 1px ${(props) => props.theme.colors.darkGrey4};
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+  }
 `;
 
 const Participants = styled.span`

--- a/src/components/home/UserInfo.tsx
+++ b/src/components/home/UserInfo.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import medalIcon from '@assets/svg_medalIcon.svg';
 import trophyIcon from '@assets/svg_trophyIcon.svg';
@@ -30,9 +30,21 @@ const UserInfo = ({ mypage }: { mypage?: boolean }) => {
             <span>로그인이 필요합니다.</span>
           ) : (
             <>
-              <span>{user?.nickname === nickname ? user.nickname : nickname}</span>
-              <span>|</span>
-              <span>10TH</span>
+              <span className="user-status-box-nickname">
+                {user?.nickname === nickname ? (
+                  user.nickname.length > 4 ? (
+                    <div>user.nickname</div>
+                  ) : (
+                    user.nickname
+                  )
+                ) : nickname.length > 4 ? (
+                  <div>nickname</div>
+                ) : (
+                  nickname
+                )}
+              </span>
+              <span className="user-status-box-slash">|</span>
+              <span className="user-status-box-rank">10TH</span>
             </>
           )}
         </UserStatusBox>
@@ -100,6 +112,19 @@ const UserImageBox = styled.div`
   background-color: white;
 `;
 
+const nicknameAnimation = keyframes`
+  from {
+    -moz-transform: translateX(50%);
+    -webkit-transform: translateX(50%);
+    transform: translateX(50%);
+  }
+  to {
+    -moz-transform: translateX(-50%);
+    -webkit-transform: translateX(-50%);
+    transform: translateX(-50%);
+  }
+`;
+
 const UserStatusBox = styled.div`
   position: absolute;
   font-size: 20px;
@@ -110,8 +135,31 @@ const UserStatusBox = styled.div`
   gap: 52px;
   padding: 25px;
   display: flex;
-  justify-content: center;
   align-items: center;
+  .user-status-box-nickname {
+    position: fixed;
+    width: 100px;
+    white-space: nowrap;
+    display: block;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+
+    div {
+      -moz-animation: ${nicknameAnimation} 7s linear infinite;
+      -webkit-animation: ${nicknameAnimation} 7s linear infinite;
+      animation: ${nicknameAnimation} 7s linear infinite;
+    }
+  }
+
+  .user-status-box-slash {
+    position: fixed;
+    margin-left: 127px;
+  }
+
+  .user-status-box-rank {
+    margin-left: 195px;
+  }
 `;
 
 const OnClickHandleButton = styled(Button)`

--- a/src/components/home/UserInfo.tsx
+++ b/src/components/home/UserInfo.tsx
@@ -33,12 +33,12 @@ const UserInfo = ({ mypage }: { mypage?: boolean }) => {
               <span className="user-status-box-nickname">
                 {user?.nickname === nickname ? (
                   user.nickname.length > 4 ? (
-                    <div>user.nickname</div>
+                    <div>{user.nickname}</div>
                   ) : (
                     user.nickname
                   )
                 ) : nickname.length > 4 ? (
-                  <div>nickname</div>
+                  <div>{nickname}</div>
                 ) : (
                   nickname
                 )}

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -6,4 +6,9 @@ export const PARTICIPANTS_OPTIONS = [
   { value: '6', label: '6' },
 ];
 
+export const COUNT_OPTIONS = [
+  { value: '30:30:60', label: '30:30:60' },
+  { value: '30:60:120', label: '30:60:120' },
+];
+
 export const BUG_OPTIONS = [{ value: '버그', label: '버그' }];


### PR DESCRIPTION
### Issue

- resolves #77

<br>

### 요약

게임만들기 입력 제한/글자 수 잘리는 부분 애니메이션 추가

<br>

### 작업 내용

- 게임 페이지 참여자 캠 status 닉네임/메인 페이지 유저 섹션 닉네임 일정 길이 넘어갈 시 애니메이션
- 방제 12자 길이 제한, 일정 길이 넘어갈 시 애니메이션(기본 방제 설정: 가치마인드 한 판 해요)
- 비밀번호 숫자 4자리 제한
- 일반방 생성 가능하게 수
- 카운트 선택지 2개 셀렉트로 수정

<br>



### 리뷰어에게 할 말

애니메이션을 최대 길이 기준으로 설정해놔서 아래 움짤처럼 길이가 많이 적으면 공백으로 보이는 시간이 있습니다
저거까지 다 설정하면,, 힘드니까 봐주삼,,
+ gif 메이커 뭐 쓰세여?,, 내껀 왤케 화질이 안좋지 ㅠ

![KakaoTalk_20230126_014508834](https://user-images.githubusercontent.com/118031423/214625012-3d6283f5-9a5a-4b29-b3ab-65c3e7301697.gif)

