### PR TITLE
FEAT: 게임 종료 시 로직, UI처리 추가

### DIFF
--- a/src/components/game/GameReady.tsx
+++ b/src/components/game/GameReady.tsx
@@ -17,6 +17,7 @@ const GameReady = () => {
   useEffect(() => {
     if (isRenderedFirstTime) {
       setIsRenderedFirstTime(false);
+      return;
     }
     emitGameReady();
   }, [debouncedReadyState]);

--- a/src/components/game/GameResultModal.tsx
+++ b/src/components/game/GameResultModal.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import styled from 'styled-components';
 
 import Button from '@components/common/Button';
@@ -5,14 +7,15 @@ import Modal from '@components/common/Modal';
 
 // TODO: SCORE 폰트가 만약 한번만 사용되면 구글 링크가 없는 관계로 이미지를 활용한다.
 const GameResultModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
+  const navigate = useNavigate();
   return (
     <Modal visible={visible} onClose={onClose} title="SCORE" width={640}>
       <GameResultModalLayout>
         <span>SCORE</span>
         <ResultBox>점수냥이</ResultBox>
         <ButtonBox>
-          <LeaveRoomButton>나가기</LeaveRoomButton>
-          <ContinueGameButton>계속하기</ContinueGameButton>
+          <LeaveRoomButton onClick={() => navigate('/', { replace: true })}>나가기</LeaveRoomButton>
+          <ContinueGameButton onClick={onClose}>계속하기</ContinueGameButton>
         </ButtonBox>
       </GameResultModalLayout>
     </Modal>

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useState } from 'react';
+
 import styled, { keyframes } from 'styled-components';
 
 import { useAppSelector } from '@redux/hooks';
 
 import GameReady from './GameReady';
+import GameResultModal from './GameResultModal';
 import GameStart from './GameStart';
 import PresentationInfo from './PresentationInfo';
 import PresenterCam from './PresenterCam';
@@ -12,10 +15,17 @@ const Presenter = () => {
   const { user } = useAppSelector((state) => state.user);
   const { room } = useAppSelector((state) => state.gameRoom);
   const { turn, playState } = useAppSelector((state) => state.gamePlay);
+  const [resultModalVisible, setResultModalVisible] = useState<boolean>(false);
   const currentUser = room?.participants.find((participant) => participant.userId === user?.userId);
   const presenterNickname =
     room?.participants.find((participant) => participant.userId === turn?.speechPlayer)?.nickname ?? '';
   const isMe = user?.userId === turn?.speechPlayer;
+
+  useEffect(() => {
+    if (playState?.event === 'gameEnd') {
+      setResultModalVisible(true);
+    }
+  }, [playState]);
 
   return (
     <PresenterLayout>
@@ -38,6 +48,9 @@ const Presenter = () => {
           {currentUser?.isHost && <GameStart />}
           {currentUser?.isHost === false && <GameReady />}
         </GameReadyBox>
+      )}
+      {resultModalVisible && (
+        <GameResultModal visible={resultModalVisible} onClose={() => setResultModalVisible(false)} />
       )}
     </PresenterLayout>
   );

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -33,7 +33,12 @@ const Presenter = () => {
         </PresenterKeywordBox>
       )}
       {room?.isGameOn && turn && <PresenterCam nickname={presenterNickname} isMe={isMe} userId={turn.speechPlayer} />}
-      {!room?.isGameOn && <GameReadyBox>{currentUser?.isHost ? <GameStart /> : <GameReady />}</GameReadyBox>}
+      {!room?.isGameOn && (
+        <GameReadyBox>
+          {currentUser?.isHost && <GameStart />}
+          {currentUser?.isHost === false && <GameReady />}
+        </GameReadyBox>
+      )}
     </PresenterLayout>
   );
 };

--- a/src/hooks/useGameTimeCountDown.ts
+++ b/src/hooks/useGameTimeCountDown.ts
@@ -19,7 +19,9 @@ const useGameTimeCountDown = () => {
     if (playState) {
       setCounter(playState.timer);
       setCounterDescription(CounterDescriptions[playState.event]);
+      return;
     }
+    setCounterDescription('');
   }, [playState]);
 
   useEffect(() => {

--- a/src/redux/modules/gamePlaySlice.ts
+++ b/src/redux/modules/gamePlaySlice.ts
@@ -19,10 +19,14 @@ const gamePlaySlice = createSlice({
     setTurn: (state, action: PayloadAction<GameTurnInfoResponse>) => {
       state.turn = action.payload;
     },
+    clearAllGamePlayState: (state) => {
+      state.playState = undefined;
+      state.turn = undefined;
+    },
   },
   extraReducers: {},
 });
 
-export const { setPlayState, setTurn } = gamePlaySlice.actions;
+export const { setPlayState, setTurn, clearAllGamePlayState } = gamePlaySlice.actions;
 
 export default gamePlaySlice;


### PR DESCRIPTION
### Issue

- resolves #75 

<br>

### 요약

방에서 게임이 종료되었을 때의 처리를 추가한다.


<br>

### 작업 내용

- 게임 레디 이벤트 emit이 룸 페이지 렌더링 시도되던 부분을 개선
- 게임 턴 모두 종료될 때 게임 플레이 상태를 초기화 하며 알림을 줌
- 게임 턴 모두 종료될 때 결과 모달창을 띄움   

![end](https://user-images.githubusercontent.com/76927397/214648561-18c98f18-798e-4348-bb20-54e6212bc700.gif)


<br>

### 리뷰어에게 할 말

아직 백엔드쪽 게임 종료 처리 로직이 완성 안되어서 게임 종료 후 바로 재시작은 안됩니다.

게임 진행하면서 자잘하게 수정해야되는 것들은 다른 이슈에서 해결하려고합니다

 
