### PR TITLE
FEAT: 게임 진행 관련 로직/UI 추가 및 개선

### DIFF
--- a/src/components/game/ChatLog.tsx
+++ b/src/components/game/ChatLog.tsx
@@ -11,12 +11,14 @@ interface ChatColorType {
   notification: string;
   answer: string;
   chat: string;
+  warning: string;
 }
 
 const ChatColor: ChatColorType = {
   notification: 'yellow',
   answer: 'green',
   chat: 'inherit',
+  warning: 'red',
 };
 
 const ChatLog = () => {
@@ -46,7 +48,7 @@ const ChatLog = () => {
       <ChatBox>
         {chatList.map((chat, index) => (
           <Chat chatColor={ChatColor[chat.type]} key={index}>
-            {chat.nickname}: {chat.message}
+            {chat.type === 'chat' ? chat.nickname + ': ' + chat.message : chat.message}
           </Chat>
         ))}
       </ChatBox>

--- a/src/components/game/PresentationInfo.tsx
+++ b/src/components/game/PresentationInfo.tsx
@@ -37,7 +37,11 @@ const PresentationInfo = ({ isMe, keyword, nickname, event }: PresentationInfoPr
                 <p>입니다.</p>
               </>
             ) : (
-              `다음 발표자는 '${nickname}'입니다.`
+              <>
+                <p>현재 발표자는</p>
+                <PresenterAnnounceText>{nickname}</PresenterAnnounceText>
+                <p>입니다.</p>
+              </>
             )}
           </div>
           <CounterText>
@@ -74,6 +78,13 @@ const KeywordText = styled.p`
   font-size: 36px;
   margin: 10px 0;
   color: red;
+`;
+
+const PresenterAnnounceText = styled.p`
+  font-size: 28px;
+  margin: 12px 0;
+  padding: 0 40px;
+  font-weight: 600;
 `;
 
 const CounterText = styled.p`

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -1,6 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 
 import { useAppSelector } from '@redux/hooks';
+import { filterKeyword } from '@utils/common';
 
 import GameReady from './GameReady';
 import GameStart from './GameStart';
@@ -27,9 +28,11 @@ const Presenter = () => {
           event={playState.event}
         />
       )}
-      {isMe && playState?.event === 'speechTimer' && (
+      {playState?.event === 'speechTimer' && turn && (
         <PresenterKeywordBox>
-          제시어:&nbsp;<span>{turn?.keyword}</span>
+          <p>
+            제시어:&nbsp;<span>{isMe ? turn.keyword : filterKeyword(turn.keyword)}</span>
+          </p>
         </PresenterKeywordBox>
       )}
       {room?.isGameOn && turn && <PresenterCam nickname={presenterNickname} isMe={isMe} userId={turn.speechPlayer} />}
@@ -78,7 +81,7 @@ const PresenterKeywordBox = styled.div`
   height: 42px;
   animation: ${KeywordSlide} 0.75s 0s;
   font-size: 14px;
-  & > span {
+  & > p > span {
     font-size: 20px;
     font-weight: 500;
   }

--- a/src/components/game/ScoreBoard.tsx
+++ b/src/components/game/ScoreBoard.tsx
@@ -1,5 +1,23 @@
+import styled from 'styled-components';
+
+import { useAppSelector } from '@redux/hooks';
+
+// TODO: 임시로 점수만 나타낸 것을 수정해야함
 const ScoreBoard = () => {
-  return <div></div>;
+  const { room } = useAppSelector((state) => state.gameRoom);
+  return (
+    <ScoreBoardLayout>
+      {room?.participants.map((participant) => (
+        <p key={participant.userId}>
+          {participant.nickname} : {participant.score ?? 0}
+        </p>
+      ))}
+    </ScoreBoardLayout>
+  );
 };
+
+const ScoreBoardLayout = styled.div`
+  color: ${(props) => props.theme.colors.white};
+`;
 
 export default ScoreBoard;

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -35,13 +35,12 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
       speechTime: Number(time.split(':')[1]) * 1000,
       discussionTime: Number(time.split(':')[2]) * 1000,
       round: 1,
-      roomPassword: isSecretRoom ? Number(roomPassword) : 1111,
+      roomPassword: Number(roomPassword),
       isSecretRoom,
     };
     emitCreateRoom(createRoom);
     onClose();
-    // TODO: 비밀번호 input 구현 후 적용
-    roomPassword && onShowCreatedRoomId(navigate, '/?roomId=', Number(roomPassword));
+    onShowCreatedRoomId(navigate, '/?roomId=', Number(roomPassword));
   };
   return (
     <Modal visible={visible} onClose={onClose} title="MAKE A ROOM">

--- a/src/components/home/CreateGameModal.tsx
+++ b/src/components/home/CreateGameModal.tsx
@@ -28,6 +28,7 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
     if (!roomTitle || maxCount < 2 || maxCount > 6 || (isSecretRoom && String(roomPassword)?.length !== 4)) {
       return;
     }
+    const password = isSecretRoom ? Number(roomPassword) : undefined;
     const createRoom: CreateRoomRequest = {
       roomTitle,
       maxCount,
@@ -35,12 +36,12 @@ const CreateGameModal = ({ visible, onClose }: { visible: boolean; onClose: () =
       speechTime: Number(time.split(':')[1]) * 1000,
       discussionTime: Number(time.split(':')[2]) * 1000,
       round: 1,
-      roomPassword: Number(roomPassword),
+      roomPassword: password,
       isSecretRoom,
     };
     emitCreateRoom(createRoom);
     onClose();
-    onShowCreatedRoomId(navigate, '/?roomId=', Number(roomPassword));
+    onShowCreatedRoomId(navigate, '/?roomId=', password);
   };
   return (
     <Modal visible={visible} onClose={onClose} title="MAKE A ROOM">

--- a/src/components/home/RoomCard.tsx
+++ b/src/components/home/RoomCard.tsx
@@ -159,7 +159,7 @@ const Title = styled.span`
     -moz-animation: ${titleAnimation} 7s linear infinite;
     -webkit-animation: ${titleAnimation} 7s linear infinite;
     animation: ${titleAnimation} 7s linear infinite;
-    text {
+    span {
       background-image: linear-gradient(
         0deg,
         rgba(121, 121, 121, 0.5) 50%,

--- a/src/components/home/RoomCard.tsx
+++ b/src/components/home/RoomCard.tsx
@@ -1,11 +1,41 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
-const RoomCard = ({ children }: { children: React.ReactNode }) => {
+import enterRoomIcon from '@assets/svg_enterRoomIcon.svg';
+import privateRoomIcon from '@assets/svg_privateRoomIcon.svg';
+
+import { GameRoomBroadcastResponse } from '@customTypes/socketType';
+
+interface RoomCardProps {
+  room: GameRoomBroadcastResponse;
+  onJoinClick: () => void;
+}
+
+const RoomCard = ({ room, onJoinClick }: RoomCardProps) => {
   return (
     <div>
       <GreyBox />
       <RoomCardTopBox />
-      <RoomCardMainBox>{children}</RoomCardMainBox>
+      <RoomCardMainBox>
+        <CardContentsBox>
+          <Title>
+            {room.roomTitle.length > 6 ? (
+              <div>
+                <span>{room.roomTitle}</span>
+              </div>
+            ) : (
+              room.roomTitle
+            )}
+          </Title>
+          <Participants>
+            참여인원: {room.participants.toString()}/{room.maxCount}
+          </Participants>
+          <EnterButton onClick={onJoinClick}>
+            참가하기
+            <img src={enterRoomIcon} />
+          </EnterButton>
+        </CardContentsBox>
+        {room.isSecretRoom && <img className="secret-room-icon" src={privateRoomIcon} />}
+      </RoomCardMainBox>
     </div>
   );
 };
@@ -49,6 +79,84 @@ const RoomCardMainBox = styled.div`
     margin-top: 25px;
     margin-left: -10px;
   }
+`;
+
+const CardContentsBox = styled.div`
+  font-family: inherit;
+  margin-left: 32px;
+  margin-top: 25px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const titleAnimation = keyframes`
+  from {
+    -moz-transform: translateX(5%);
+    -webkit-transform: translateX(5%);
+    transform: translateX(5%);
+  }
+  to {
+    -moz-transform: translateX(-105%);
+    -webkit-transform: translateX(-105%);
+    transform: translateX(-105%);
+  }
+`;
+
+const Title = styled.span`
+  background-image: linear-gradient(0deg, rgba(121, 121, 121, 0.5) 50%, ${(props) => props.theme.colors.ivory2} 50%);
+  background-clip: text;
+  -webkit-text-stroke: 1px ${(props) => props.theme.colors.darkGrey4};
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-family: inherit;
+  font-size: 20px;
+  line-height: 150%;
+  width: 130px;
+  white-space: nowrap;
+  display: block;
+  overflow: hidden;
+
+  div {
+    -moz-animation: ${titleAnimation} 7s linear infinite;
+    -webkit-animation: ${titleAnimation} 7s linear infinite;
+    animation: ${titleAnimation} 7s linear infinite;
+    text {
+      background-image: linear-gradient(
+        0deg,
+        rgba(121, 121, 121, 0.5) 50%,
+        ${(props) => props.theme.colors.ivory2} 50%
+      );
+      background-clip: text;
+      -webkit-text-stroke: 1px ${(props) => props.theme.colors.darkGrey4};
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+  }
+`;
+
+const Participants = styled.span`
+  font-family: inherit;
+  font-size: 12px;
+  color: ${(props) => props.theme.colors.lightGrey5};
+  opacity: 0.5;
+`;
+
+const EnterButton = styled.button`
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  color: ${(props) => props.theme.colors.ivory2};
+  text-shadow: ${(props) => props.theme.textShadow.textShadow1};
+  background-color: ${(props) => props.theme.colors.darkGrey2};
+  margin-top: 12px;
+  width: 96px;
+  height: 40px;
+  gap: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${(props) => props.theme.borders.topLeftGreyBorder}
 `;
 
 export default RoomCard;

--- a/src/components/home/RoomList.tsx
+++ b/src/components/home/RoomList.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 
-import enterRoomIcon from '@assets/svg_enterRoomIcon.svg';
-import privateRoomIcon from '@assets/svg_privateRoomIcon.svg';
 import roomListLeftIcon from '@assets/svg_roomListLeftIcon.svg';
 import roomListRightIcon from '@assets/svg_roomListRightIcon.svg';
 import { useAuthSocket } from '@hooks/socket/useAuthSocket';
@@ -86,27 +84,7 @@ const RoomList = () => {
           .filter((room) => room.participants !== 0)
           .slice(offset, offset + 9)
           .map((room) => (
-            <RoomCard key={room.roomId}>
-              <CardContentsBox>
-                <Title>
-                  {room.roomTitle.length > 6 ? (
-                    <div>
-                      <text>{room.roomTitle}</text>
-                    </div>
-                  ) : (
-                    room.roomTitle
-                  )}
-                </Title>
-                <Participants>
-                  참여인원: {room.participants.toString()}/{room.maxCount}
-                </Participants>
-                <EnterButton onClick={() => handleJoinRoomClick(room.roomId)}>
-                  참가하기
-                  <img src={enterRoomIcon} />
-                </EnterButton>
-              </CardContentsBox>
-              {room.isSecretRoom && <img className="secret-room-icon" src={privateRoomIcon} />}
-            </RoomCard>
+            <RoomCard key={room.roomId} room={room} onJoinClick={() => handleJoinRoomClick(room.roomId)} />
           ))}
       </RoomListLayout>
     </>
@@ -133,84 +111,6 @@ const RoomPaginationBox = styled.div`
     cursor: pointer;
     background: none;
   }
-`;
-
-const CardContentsBox = styled.div`
-  font-family: inherit;
-  margin-left: 32px;
-  margin-top: 25px;
-  display: flex;
-  flex-direction: column;
-`;
-
-const titleAnimation = keyframes`
-  from {
-    -moz-transform: translateX(5%);
-    -webkit-transform: translateX(5%);
-    transform: translateX(5%);
-  }
-  to {
-    -moz-transform: translateX(-105%);
-    -webkit-transform: translateX(-105%);
-    transform: translateX(-105%);
-  }
-`;
-
-const Title = styled.span`
-  background-image: linear-gradient(0deg, rgba(121, 121, 121, 0.5) 50%, ${(props) => props.theme.colors.ivory2} 50%);
-  background-clip: text;
-  -webkit-text-stroke: 1px ${(props) => props.theme.colors.darkGrey4};
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  font-family: inherit;
-  font-size: 20px;
-  line-height: 150%;
-  width: 130px;
-  white-space: nowrap;
-  display: block;
-  overflow: hidden;
-
-  div {
-    -moz-animation: ${titleAnimation} 7s linear infinite;
-    -webkit-animation: ${titleAnimation} 7s linear infinite;
-    animation: ${titleAnimation} 7s linear infinite;
-    text {
-      background-image: linear-gradient(
-        0deg,
-        rgba(121, 121, 121, 0.5) 50%,
-        ${(props) => props.theme.colors.ivory2} 50%
-      );
-      background-clip: text;
-      -webkit-text-stroke: 1px ${(props) => props.theme.colors.darkGrey4};
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-    }
-  }
-`;
-
-const Participants = styled.span`
-  font-family: inherit;
-  font-size: 12px;
-  color: ${(props) => props.theme.colors.lightGrey5};
-  opacity: 0.5;
-`;
-
-const EnterButton = styled.button`
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 14px;
-  color: ${(props) => props.theme.colors.ivory2};
-  text-shadow: ${(props) => props.theme.textShadow.textShadow1};
-  background-color: ${(props) => props.theme.colors.darkGrey2};
-  margin-top: 12px;
-  width: 96px;
-  height: 40px;
-  gap: 8px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  ${(props) => props.theme.borders.topLeftGreyBorder}
 `;
 
 export default RoomList;

--- a/src/constants/socket.ts
+++ b/src/constants/socket.ts
@@ -28,6 +28,7 @@ export const SUBSCRIBE = Object.freeze({
   gameTimeStart: 'time-start',
   gameTimeEnd: 'time-end',
   getGameInfo: 'game-info',
+  getScore: 'score',
 
   // webRTC
   webRTCIce: 'webrtc-ice',

--- a/src/hooks/socket/useChatSocket.ts
+++ b/src/hooks/socket/useChatSocket.ts
@@ -13,9 +13,12 @@ const useChatSocket = () => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    on(SUBSCRIBE.receiveChat, ({ data }: { data: { message: string; eventUserInfo: EventUserInfo } }) => {
-      dispatch(addChat({ ...data.eventUserInfo, message: data.message, type: 'chat' }));
-    });
+    on(
+      SUBSCRIBE.receiveChat,
+      ({ data }: { data: { message: string; eventUserInfo: EventUserInfo; type: 'chat' | 'answer' } }) => {
+        dispatch(addChat({ ...data.eventUserInfo, message: data.message, type: data.type }));
+      },
+    );
     return () => {
       off(SUBSCRIBE.receiveChat);
     };

--- a/src/hooks/socket/useErrorSocket.ts
+++ b/src/hooks/socket/useErrorSocket.ts
@@ -9,7 +9,7 @@ import socketInstance from './socketInstance';
 interface ErrorConditionType {
   target: keyof ErrorResponse;
   value: string | number;
-  callback?: () => void;
+  callback?: (msg?: string) => void;
   skipAlert?: boolean;
 }
 
@@ -24,7 +24,8 @@ const useErrorSocket = () => {
             alertToast(error.errorMessage, 'warning', {
               hideProgressBar: true,
             });
-          condition?.callback?.();
+          condition?.callback?.(error.errorMessage);
+          return;
         }
       });
     });

--- a/src/hooks/socket/useGamePlaySocket.ts
+++ b/src/hooks/socket/useGamePlaySocket.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { SUBSCRIBE } from '@constants/socket';
 import { useAppDispatch } from '@redux/hooks';
 import { setPlayState, setTurn } from '@redux/modules/gamePlaySlice';
-import { setIsGameOnState } from '@redux/modules/gameRoomSlice';
+import { setIsGameOnState, setScore } from '@redux/modules/gameRoomSlice';
 
 import { GameEndResponse, GameStartResponse, GameTurnInfoResponse } from '@customTypes/socketType';
 
@@ -42,8 +42,16 @@ const useGamePlaySocket = () => {
       dispatch(setTurn(data));
     });
 
+    on(SUBSCRIBE.getScore, ({ data }: { data: { userId: number; score: number } }) => {
+      console.log('[on] score');
+      dispatch(setScore({ ...data }));
+    });
+
     return () => {
       off(SUBSCRIBE.gameTimeStart);
+      off(SUBSCRIBE.gameTimeEnd);
+      off(SUBSCRIBE.getGameInfo);
+      off(SUBSCRIBE.getScore);
     };
   }, []);
 };

--- a/src/hooks/socket/useGameSocket.ts
+++ b/src/hooks/socket/useGameSocket.ts
@@ -9,7 +9,7 @@ import { CreateRoomRequest, EnterRoomRequest } from '@customTypes/socketType';
 import socketInstance from './socketInstance';
 
 interface UseGameSocketType {
-  onShowCreatedRoomId: (navigate: NavigateFunction, path: string, password: number) => void;
+  onShowCreatedRoomId: (navigate: NavigateFunction, path: string, password?: number) => void;
   onJoinRoom: () => void;
   onValidRoomPassword: (callback: () => void) => void;
   emitUserLeaveRoom: () => void;

--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -25,12 +25,14 @@ const useWebRTC = () => {
         });
         peerConnection.onicecandidate = (e) => {
           if (e.candidate) {
-            emit(SUBSCRIBE.webRTCIce, {
-              data: {
-                ice: e.candidate,
-                candidateReceiveSocketId: peerSocketId,
-              },
-            });
+            setTimeout(() => {
+              emit(SUBSCRIBE.webRTCIce, {
+                data: {
+                  ice: e.candidate,
+                  candidateReceiveSocketId: peerSocketId,
+                },
+              });
+            }, 500);
           }
         };
         if (!userStreamRef?.current) {

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { PUBLISH } from '@constants/socket';
 import useErrorSocket from '@hooks/socket/useErrorSocket';

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -12,10 +12,13 @@ import MainTemplate from '@components/layout/MainTemplate';
 
 const Main = () => {
   const dispatch = useAppDispatch();
-  const { onError } = useErrorSocket();
+  const { onError, offError } = useErrorSocket();
 
   useEffect(() => {
     onError([{ target: 'event', value: PUBLISH.login, callback: () => dispatch(logout()) }]);
+    return () => {
+      offError();
+    };
   }, []);
 
   return (

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -9,7 +9,8 @@ import useGamePlaySocket from '@hooks/socket/useGamePlaySocket';
 import useGameSocket from '@hooks/socket/useGameSocket';
 import useGameUpdateSocket from '@hooks/socket/useGameUpdateSocket';
 import useLocalStream from '@hooks/useLocalStream';
-import { useAppSelector } from '@redux/hooks';
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { addChat } from '@redux/modules/gameRoomSlice';
 import { alertToast } from '@utils/toast';
 
 import CamList from '@components/game/CamList';
@@ -24,6 +25,7 @@ import RoomTemplate from '@components/layout/RoomTemplate';
 const Room = () => {
   const { id } = useParams();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const { authorized } = useAuthSocket();
   const { userStreamRef, isMediaSuccess } = useAppSelector((state) => state.userMedia);
   const { lastEnteredRoom, broadcastedRooms } = useAppSelector((state) => state.gameRoom);
@@ -75,7 +77,16 @@ const Room = () => {
       const intId = parseInt(id, 10);
       !Number.isNaN(intId) && emitJoinRoom({ roomId: intId, roomPassword: lastEnteredRoom?.password });
       onJoinRoom();
-      onError([{ target: 'event', value: 'enter-room', callback: () => navigate('/', { replace: true }) }]);
+      onError([
+        { target: 'event', value: 'enter-room', callback: () => navigate('/', { replace: true }) },
+        {
+          target: 'event',
+          value: 'send-chat',
+          callback: (msg: string | undefined) =>
+            dispatch(addChat({ message: msg as string, nickname: '', type: 'warning', socketId: '', userId: 0 })),
+          skipAlert: true,
+        },
+      ]);
     }
   }, [id, authorized, isConfirmedUser]);
 

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -68,6 +68,8 @@ const Room = () => {
       }
       if (broadcastedRooms.find((room) => room.roomId === parsedId)?.isSecretRoom) {
         setPasswordModalVisible(true);
+      } else {
+        setIsConfirmedUser(true);
       }
     }
   }, [userStreamRef]);

--- a/src/redux/modules/gameRoomSlice.ts
+++ b/src/redux/modules/gameRoomSlice.ts
@@ -49,6 +49,16 @@ const gameRoomSlice = createSlice({
     setIsGameOnState: (state, action: PayloadAction<boolean>) => {
       state.room = { ...(state.room as GameRoomDetail), isGameOn: action.payload };
     },
+    setScore: (state, action: PayloadAction<{ userId: number; score: number }>) => {
+      const { userId, score } = action.payload;
+      if (!state.room?.participants) {
+        return;
+      }
+      const participants = state.room.participants.map((participant) =>
+        participant.userId === userId ? { ...participant, score: (participant.score ?? 0) + score } : participant,
+      );
+      state.room = { ...state.room, participants };
+    },
   },
   extraReducers: {},
 });
@@ -61,6 +71,7 @@ export const {
   clearChatList,
   setLastEnteredRoom,
   setIsGameOnState,
+  setScore,
 } = gameRoomSlice.actions;
 
 export default gameRoomSlice;

--- a/src/types/gameRoomType.ts
+++ b/src/types/gameRoomType.ts
@@ -27,6 +27,7 @@ export interface Participant {
   audio?: boolean;
   video?: boolean;
   isHost?: boolean;
+  score?: number;
 }
 
 export interface ChatBaseType {

--- a/src/types/gameRoomType.ts
+++ b/src/types/gameRoomType.ts
@@ -37,5 +37,5 @@ export interface Chat extends ChatBaseType {
   userId: number;
   socketId: string;
   nickname: string;
-  type: 'chat' | 'notification' | 'answer';
+  type: 'chat' | 'notification' | 'answer' | 'warning';
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -8,7 +8,6 @@ export const convertLeaveCounterFormat = (counter: number, hasMinute?: boolean) 
   return hasMinute ? `0${Math.floor(counter / 60000)}:` + second : second;
 };
 
-// XXX: 각 단어 하나하나가 영문/한글/숫자 여부도 알려줘야할까?
 export const filterKeyword = (keyword: string) => {
-  return keyword.replace(/[가-힣a-zA-Z]/gi, 'O');
+  return keyword.replace(/[가-힣a-zA-Z]/gi, '_');
 };

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -7,3 +7,8 @@ export const convertLeaveCounterFormat = (counter: number, hasMinute?: boolean) 
   const second = ((counter % 60000) / 1000).toString().padStart(2, '0');
   return hasMinute ? `0${Math.floor(counter / 60000)}:` + second : second;
 };
+
+// XXX: 각 단어 하나하나가 영문/한글/숫자 여부도 알려줘야할까?
+export const filterKeyword = (keyword: string) => {
+  return keyword.replace(/[가-힣a-zA-Z]/gi, 'O');
+};


### PR DESCRIPTION
### Issue

- resolves #76 

<br>

### 요약

게임방 관련 일부 로직을 개선하고 게임중일 때 정답 처리를 추가한다.


<br>

### 작업 내용

- [X] 발표자 이외의 게임 참여자에게 키워드의 글자수만 보여주도록 추가
- [X] 게임[발표중] 일 때 발표자를 제외한 게임방의 인원들에게 키워드의 글자 수를 보여준다.
- [x] 게임이 진행 중일 경우, 꽉 찬 경우, 비로그인 상태일 경우 방 목록에서 클릭하여 입장을 시도할 수 없다.
- [X] 게임 진행 중일 때 정답 채팅에 대한 처리(스코어 적용)를 추가한다.
- [X] 발표자가 정답을 채팅입력할 때의 이벤트에 대한 처리를 추가한다.

<br>

![game2](https://user-images.githubusercontent.com/76927397/214708743-65574699-dead-4997-91c3-07aa0475779b.gif)


![image](https://user-images.githubusercontent.com/76927397/214779447-c7e231f6-aeda-4573-a0a9-103f97fcc954.png)


<br>

### 리뷰어에게 할 말

RoomCard를 children을 가지는게 아니라 room props를 받아서 구현되게끔 리팩터링했습니다. 스타일은 안 건드리고 컴포넌트만 잘 RoomList와 분리했습니다.

방 하나에 대한 로직을 쉽게 처리하려고 분리했습니다.


<br>



 
