### PR TITLE
FEAT: 게임 결과 그래프에 스코어 반영 및 캠 관련 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-singleton-hook": "^4.0.1",
         "react-slick": "^0.29.0",
         "react-toastify": "^9.1.1",
+        "react-tooltip": "^5.7.0",
         "socket.io-client": "^4.5.4",
         "styled-components": "^5.3.6",
         "typescript": "^4.9.4",
@@ -36,6 +37,7 @@
       "devDependencies": {
         "@types/react-redux": "^7.1.25",
         "@types/react-slick": "^0.23.10",
+        "@types/react-tooltip": "^4.2.4",
         "@types/styled-components": "^5.1.26",
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "@typescript-eslint/parser": "^5.48.0",
@@ -2295,6 +2297,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
+      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.5"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -4035,6 +4050,16 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-tooltip": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-tooltip/-/react-tooltip-4.2.4.tgz",
+      "integrity": "sha512-UzjzmgY/VH3Str6DcAGTLMA1mVVhGOyARNTANExrirtp+JgxhaIOVDxq4TIRmpSi4voLv+w4HA9CC5GvhhCA0A==",
+      "deprecated": "This is a stub types definition. react-tooltip provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "react-tooltip": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -15021,6 +15046,19 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/react-tooltip": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.7.0.tgz",
+      "integrity": "sha512-bkCwwwL1T1amT6cTiA5wPPBYZ3duVVC+5FY4ZHgQzRyuXb6SxRxPZNKMWh4eSyHjMiFTSg0hfBd8Pad9iuCnWg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.4",
+        "classnames": "^2.3.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -19513,6 +19551,19 @@
         }
       }
     },
+    "@floating-ui/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
+      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "requires": {
+        "@floating-ui/core": "^1.0.5"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -20809,6 +20860,15 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-tooltip": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-tooltip/-/react-tooltip-4.2.4.tgz",
+      "integrity": "sha512-UzjzmgY/VH3Str6DcAGTLMA1mVVhGOyARNTANExrirtp+JgxhaIOVDxq4TIRmpSi4voLv+w4HA9CC5GvhhCA0A==",
+      "dev": true,
+      "requires": {
+        "react-tooltip": "*"
       }
     },
     "@types/resolve": {
@@ -28624,6 +28684,15 @@
       "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
       "requires": {
         "clsx": "^1.1.1"
+      }
+    },
+    "react-tooltip": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.7.0.tgz",
+      "integrity": "sha512-bkCwwwL1T1amT6cTiA5wPPBYZ3duVVC+5FY4ZHgQzRyuXb6SxRxPZNKMWh4eSyHjMiFTSg0hfBd8Pad9iuCnWg==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.4",
+        "classnames": "^2.3.2"
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-singleton-hook": "^4.0.1",
     "react-slick": "^0.29.0",
     "react-toastify": "^9.1.1",
+    "react-tooltip": "^5.7.0",
     "socket.io-client": "^4.5.4",
     "styled-components": "^5.3.6",
     "typescript": "^4.9.4",
@@ -56,6 +57,7 @@
   "devDependencies": {
     "@types/react-redux": "^7.1.25",
     "@types/react-slick": "^0.23.10",
+    "@types/react-tooltip": "^4.2.4",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import './app.css';
+import 'react-tooltip/dist/react-tooltip.css';
 
 import { Provider } from 'react-redux';
 import { SingletonHooksContainer } from 'react-singleton-hook';

--- a/src/components/game/CamUserStatus.tsx
+++ b/src/components/game/CamUserStatus.tsx
@@ -16,11 +16,13 @@ const CamStatusStyles = {
     fontSize: '12px',
     gap: '6px',
     padding: '8px 8px',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   main: {
     fontSize: '18px',
     gap: '16px',
     padding: '12px 24px',
+    backgroundColor: 'rgba(0, 0, 0, 0.9)',
   },
 };
 
@@ -28,6 +30,7 @@ interface CamStatusStylesProps {
   fontSize: string;
   gap: string;
   padding: string;
+  backgroundColor: string;
 }
 
 const CamUserStatus = ({ nickname, isMicOn, size = 'sub' }: CamUserStatusProps) => {
@@ -55,7 +58,7 @@ const CamUserStatusLayout = styled.div<{ customStyles: CamStatusStylesProps }>`
   padding: ${(props) => props.customStyles.padding};
   align-items: center;
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: ${(props) => props.customStyles.backgroundColor};
 
   div {
     gap: ${(props) => props.customStyles.gap};

--- a/src/components/game/GameResultModal.tsx
+++ b/src/components/game/GameResultModal.tsx
@@ -1,25 +1,44 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import styled, { keyframes } from 'styled-components';
 
+import { useAppDispatch } from '@redux/hooks';
+import { clearScore } from '@redux/modules/gameRoomSlice';
+
 import Button from '@components/common/Button';
 import Modal from '@components/common/Modal';
 
-const GameResultModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
-  const participants = 3;
+import { Participant } from '@customTypes/gameRoomType';
+
+interface GameResultModalProps {
+  visible: boolean;
+  onClose: () => void;
+  participants: Participant[];
+}
+
+const GameResultModal = ({ visible, onClose, participants }: GameResultModalProps) => {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const sortedScore = participants.map((participant) => participant.score ?? 0).sort((o1, o2) => o2 - o1);
+  const maxScore = sortedScore[0];
+
+  useEffect(() => {
+    return () => {
+      dispatch(clearScore());
+    };
+  }, []);
+
   return (
     <Modal visible={visible} onClose={onClose} title="SCORE" width={640}>
       <GameResultModalLayout>
-        <span>YOUR SCORE</span>
+        <span>SCORE RESULT</span>
         <ResultBox>
           <ul>
-            <li style={{ height: participants < 5 ? '20px' : '100px' }}></li>
-            <li style={{ height: participants < 3 ? '20px' : '180px' }}></li>
-            <li style={{ height: '281px' }}></li>
-            <li style={{ height: '220px' }}></li>
-            <li style={{ height: participants < 4 ? '20px' : '161px' }}></li>
-            <li style={{ height: participants < 6 ? '20px' : '81px' }}></li>
+            {[...Array(6)].map((_, index) => {
+              const height = sortedScore[index] === 0 ? 10 : sortedScore[index] ?? 2;
+              return <li key={index} style={{ height: ((height / maxScore) * 80).toString() + '%' }} />;
+            })}
           </ul>
         </ResultBox>
         <ButtonBox>
@@ -74,6 +93,7 @@ const ResultBox = styled.div`
     flex-direction: row;
     align-items: flex-end;
     overflow: hidden;
+    height: 100%;
   }
 
   li {

--- a/src/components/game/GameResultModal.tsx
+++ b/src/components/game/GameResultModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { Tooltip as ReactTooltip } from 'react-tooltip';
 import styled, { keyframes } from 'styled-components';
 
 import { useAppDispatch } from '@redux/hooks';
@@ -15,12 +16,14 @@ interface GameResultModalProps {
   visible: boolean;
   onClose: () => void;
   participants: Participant[];
+  userId: number;
 }
 
-const GameResultModal = ({ visible, onClose, participants }: GameResultModalProps) => {
+const GameResultModal = ({ visible, onClose, participants, userId }: GameResultModalProps) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const sortedScore = participants.map((participant) => participant.score ?? 0).sort((o1, o2) => o2 - o1);
+  const sortedParticipants = [...participants].sort((o1, o2) => o2.score - o1.score);
+  const sortedScore = sortedParticipants.map((participant) => participant.score);
   const maxScore = sortedScore[0];
 
   useEffect(() => {
@@ -37,7 +40,25 @@ const GameResultModal = ({ visible, onClose, participants }: GameResultModalProp
           <ul>
             {[...Array(6)].map((_, index) => {
               const height = sortedScore[index] === 0 ? 10 : sortedScore[index] ?? 2;
-              return <li key={index} style={{ height: ((height / maxScore) * 80).toString() + '%' }} />;
+              console.log(height);
+              return (
+                <>
+                  <li
+                    id={'id-chart-' + index}
+                    key={index}
+                    style={{ height: ((height / maxScore) * 80).toString() + '%' }}
+                  />
+                  {sortedScore[index] !== undefined && (
+                    <ReactTooltip anchorId={'id-chart-' + index} place="left">
+                      <p style={{ fontSize: '18px', marginBottom: '10px' }}>
+                        &nbsp;{sortedParticipants[index].nickname}
+                        {userId === sortedParticipants[index].userId && '(ME)'}
+                      </p>
+                      <p style={{ fontSize: '16px' }}>&nbsp;{sortedParticipants[index].score + '점'}</p>
+                    </ReactTooltip>
+                  )}
+                </>
+              );
             })}
           </ul>
         </ResultBox>

--- a/src/components/game/GameResultModal.tsx
+++ b/src/components/game/GameResultModal.tsx
@@ -39,7 +39,7 @@ const GameResultModal = ({ visible, onClose, participants, userId }: GameResultM
         <ResultBox>
           <ul>
             {[...Array(6)].map((_, index) => {
-              const height = sortedScore[index] === 0 ? 10 : sortedScore[index] ?? 2;
+              const height = sortedScore[index] === 0 ? 15 : sortedScore[index] ?? 10;
               console.log(height);
               return (
                 <>

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -52,8 +52,12 @@ const Presenter = () => {
           {currentUser?.isHost === false && <GameReady />}
         </GameReadyBox>
       )}
-      {resultModalVisible && (
-        <GameResultModal visible={resultModalVisible} onClose={() => setResultModalVisible(false)} />
+      {resultModalVisible && room && (
+        <GameResultModal
+          visible={resultModalVisible}
+          onClose={() => setResultModalVisible(false)}
+          participants={room.participants}
+        />
       )}
     </PresenterLayout>
   );

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -57,6 +57,7 @@ const Presenter = () => {
           visible={resultModalVisible}
           onClose={() => setResultModalVisible(false)}
           participants={room.participants}
+          userId={user?.userId as number}
         />
       )}
     </PresenterLayout>

--- a/src/components/game/PresenterCam.tsx
+++ b/src/components/game/PresenterCam.tsx
@@ -15,14 +15,8 @@ interface PresenterCamProps {
 
 const PresenterCam = ({ nickname, isMe, userId }: PresenterCamProps) => {
   const { playerStreamMap, playerList } = useAppSelector((state) => state.playerMedia);
-  const [currentPlayer, setCurrentPlayer] = useState<WebRTCUser>();
   const { userStream, userMic } = useAppSelector((state) => state.userMedia);
-
-  useEffect(() => {
-    if (!isMe) {
-      setCurrentPlayer(playerList.find((player) => player.userId === userId));
-    }
-  }, [userId]);
+  const currentPlayer = playerList.find((player) => player.userId === userId);
 
   return (
     <PresenterCamLayout>

--- a/src/components/game/PresenterCam.tsx
+++ b/src/components/game/PresenterCam.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useState } from 'react';
-
 import styled from 'styled-components';
 
 import { useAppSelector } from '@redux/hooks';
-import { WebRTCUser } from '@redux/modules/playerMediaSlice';
 
 import Cam from './Cam';
 

--- a/src/hooks/socket/useGamePlaySocket.ts
+++ b/src/hooks/socket/useGamePlaySocket.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { PUBLISH, SUBSCRIBE } from '@constants/socket';
+import { SUBSCRIBE } from '@constants/socket';
 import { useAppDispatch } from '@redux/hooks';
 import { clearAllGamePlayState, setPlayState, setTurn } from '@redux/modules/gamePlaySlice';
 import { setIsGameOnState, setScore } from '@redux/modules/gameRoomSlice';
@@ -11,7 +11,7 @@ import { GameEndResponse, GameStartResponse, GameTurnInfoResponse } from '@custo
 import socketInstance from './socketInstance';
 
 const useGamePlaySocket = () => {
-  const { on, off, emit } = socketInstance;
+  const { on, off } = socketInstance;
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -40,8 +40,6 @@ const useGamePlaySocket = () => {
         setTimeout(() => {
           dispatch(clearAllGamePlayState());
         }, 1500);
-        // FIXME: 서버에서 레디상태 초기화 해줄 경우 삭제할 것
-        emit(PUBLISH.readyGame);
       }
     });
 

--- a/src/redux/modules/gameRoomSlice.ts
+++ b/src/redux/modules/gameRoomSlice.ts
@@ -59,6 +59,15 @@ const gameRoomSlice = createSlice({
       );
       state.room = { ...state.room, participants };
     },
+    clearScore: (state) => {
+      if (!state.room?.participants) {
+        return;
+      }
+      const participants = state.room.participants.map((participant) => {
+        return { ...participant, score: undefined };
+      });
+      state.room = { ...state.room, participants };
+    },
   },
   extraReducers: {},
 });
@@ -72,6 +81,7 @@ export const {
   setLastEnteredRoom,
   setIsGameOnState,
   setScore,
+  clearScore,
 } = gameRoomSlice.actions;
 
 export default gameRoomSlice;

--- a/src/redux/modules/gameRoomSlice.ts
+++ b/src/redux/modules/gameRoomSlice.ts
@@ -64,7 +64,7 @@ const gameRoomSlice = createSlice({
         return;
       }
       const participants = state.room.participants.map((participant) => {
-        return { ...participant, score: undefined };
+        return { ...participant, score: 0 };
       });
       state.room = { ...state.room, participants };
     },

--- a/src/types/gameRoomType.ts
+++ b/src/types/gameRoomType.ts
@@ -27,7 +27,7 @@ export interface Participant {
   audio?: boolean;
   video?: boolean;
   isHost?: boolean;
-  score?: number;
+  score: number;
 }
 
 export interface ChatBaseType {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -9,5 +9,5 @@ export const convertLeaveCounterFormat = (counter: number, hasMinute?: boolean) 
 };
 
 export const filterKeyword = (keyword: string) => {
-  return keyword.replace(/[가-힣a-zA-Z]/gi, '_');
+  return keyword.replace(/[가-힣a-zA-Z]/gi, '🐟');
 };


### PR DESCRIPTION
### Issue

- resolves #86 

<br>

### 요약

게임 결과 그래프에 스코어를 반영하고 캠 UI관련 자잘한 문제를 해결한다.

<br>

### 작업 내용

- 사용자 수와 사용자의 스코어에 맞춰서 그래프를 적절하게 그린다.
- 그래프에 툴팁으로 부가정보를 표시해준다.
- 메인 발표자 캠 마이크가 켜저도 다른사람에게 보이지 않던 부분 수정
- 메인 캠 크기 조정
- 키워드 언더바라 글자수 식별이 안되는 점 개선

<br>

### 특이사항

- 리액트 툴팁 사용

```
npm install react-tooltip
npm install @types/react-toolip -D
```

![game2](https://user-images.githubusercontent.com/76927397/214869149-83b5074b-b7f9-44f8-9189-c2d1c983cf89.gif)


<br>

### 리뷰어에게 할 말

- 사람 수에 맞춰서 가운데에 표시하는 건 알고리즘 문제 풀 듯 로직이나 코드가 너무 복잡해질 것 같아서 스코어 내림차순으로 사람 수만큼 표시하게끔 변경해봤는데 어떤가요?

- 어차피 고양이를 올려야 하고 본인여부는 그래프 색을 좀 다르게 표현한다던가 하고 스코어는 그래프 밑에 보여줘도 되지만 보조적인 느낌으로 툴팁도 넣어봤는데 어떤가여? 아이콘 같은 곳에도 좀 쓸 수 있을 것 같아서 설치해봤습니다
 
