### PR TITLE
REFACTOR: Modal ClickAway 및 뒷 배경 선택적으로 적용할 수 있도록 수정

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -11,12 +11,22 @@ interface ModalProps {
   title: string;
   width?: number;
   children: React.ReactNode;
+  isBackgroundClickEventDisabled?: boolean;
+  hasBackgroundShadow?: boolean;
   onClose: () => void;
 }
 
-const Modal = ({ visible, title, width, children, onClose }: ModalProps) => {
+const Modal = ({
+  visible,
+  title,
+  width,
+  children,
+  onClose,
+  isBackgroundClickEventDisabled = false,
+  hasBackgroundShadow = true,
+}: ModalProps) => {
   const ref = useRef(null);
-  useClickAway(ref, () => onClose && onClose());
+  useClickAway(ref, () => !isBackgroundClickEventDisabled && onClose && onClose());
   const portalDiv = document.querySelector('#modal-root');
 
   if (!portalDiv) {
@@ -26,7 +36,7 @@ const Modal = ({ visible, title, width, children, onClose }: ModalProps) => {
     <>
       {visible &&
         createPortal(
-          <ModalBackgroundLayout visible={visible}>
+          <ModalBackgroundLayout visible={visible} hasBackgroundShadow={hasBackgroundShadow ?? false}>
             <ModalBox ref={ref} width={width}>
               <ModalHeader>
                 {title}
@@ -43,7 +53,7 @@ const Modal = ({ visible, title, width, children, onClose }: ModalProps) => {
   );
 };
 
-const ModalBackgroundLayout = styled.div<{ visible: boolean }>`
+const ModalBackgroundLayout = styled.div<{ visible: boolean; hasBackgroundShadow: boolean }>`
   display: ${({ visible }) => (visible ? 'block' : 'none')};
   position: fixed;
   transform: scale(${(props) => props.theme.layout.scale});
@@ -53,6 +63,7 @@ const ModalBackgroundLayout = styled.div<{ visible: boolean }>`
   bottom: 0;
   z-index: 999;
   min-height: 100vh;
+  background: ${(props) => (props.hasBackgroundShadow ? ' rgba(0, 0, 0, 0.6)' : 'inherit')};
   padding-right: 15vw;
   padding-left: 15vw;
   display: flex;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -36,24 +36,36 @@ const Modal = ({
     <>
       {visible &&
         createPortal(
-          <ModalBackgroundLayout visible={visible} hasBackgroundShadow={hasBackgroundShadow ?? false}>
-            <ModalBox ref={ref} width={width}>
-              <ModalHeader>
-                {title}
-                <ModalCloseButton onClick={() => onClose && onClose()}>
-                  <img src={CloseModalIcon} />
-                </ModalCloseButton>
-              </ModalHeader>
-              {children}
-            </ModalBox>
-          </ModalBackgroundLayout>,
+          <ModalLayout hasBackgroundShadow={hasBackgroundShadow ?? false}>
+            <ModalBackgroundLayout visible={visible}>
+              <ModalBox ref={ref} width={width}>
+                <ModalHeader>
+                  {title}
+                  <ModalCloseButton onClick={() => onClose && onClose()}>
+                    <img src={CloseModalIcon} />
+                  </ModalCloseButton>
+                </ModalHeader>
+                {children}
+              </ModalBox>
+            </ModalBackgroundLayout>
+          </ModalLayout>,
           portalDiv,
         )}
     </>
   );
 };
 
-const ModalBackgroundLayout = styled.div<{ visible: boolean; hasBackgroundShadow: boolean }>`
+const ModalLayout = styled.div<{ hasBackgroundShadow: boolean }>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 998;
+  width: 100vw;
+  height: 100vh;
+  background: ${(props) => (props.hasBackgroundShadow ? 'rgba(0, 0, 0, 0.6)' : 'inherit')};
+`;
+
+const ModalBackgroundLayout = styled.div<{ visible: boolean }>`
   display: ${({ visible }) => (visible ? 'block' : 'none')};
   position: fixed;
   transform: scale(${(props) => props.theme.layout.scale});
@@ -63,7 +75,6 @@ const ModalBackgroundLayout = styled.div<{ visible: boolean; hasBackgroundShadow
   bottom: 0;
   z-index: 999;
   min-height: 100vh;
-  background: ${(props) => (props.hasBackgroundShadow ? ' rgba(0, 0, 0, 0.6)' : 'inherit')};
   padding-right: 15vw;
   padding-left: 15vw;
   display: flex;


### PR DESCRIPTION
### Issue

- resolves #50 

<br>

### 요약

어떤 모달에서는 clickAway를 없애거나 뒷배경을 시커멓게해서 사용하고 싶다.


<br>

### 작업 내용

- 모달 props에 옵셔널 타입으로 배경 clickAway 이벤트를 적용할 지 말지 선택할 수 있도록 함 (기본: clickAway 적용)
- 모달 props에 옵셔널 타입으로 배경 그림자를 적용할 지 말지 선택할 수 있도록 함 (기본: 그림자: on)

<br>


![image](https://user-images.githubusercontent.com/76927397/214876599-7e53d2b7-8c85-49ba-9d1f-d808e4e00a86.png)


<br>

### 리뷰어에게 할 말

우선 기본으로 배경 그림자 적용되게 설정했습니다.

모달왜케많나요저희

<br>

 
