### PR TITLE
FEAT: 게임 중 Discussion Time에 발표자를 평가하는 기능과 UI를 추가

### DIFF
--- a/src/constants/socket.ts
+++ b/src/constants/socket.ts
@@ -7,6 +7,7 @@ export const PUBLISH = Object.freeze({
   startGame: 'start',
   readyGame: 'ready',
   validRoomPassword: 'valid-room-password',
+  sendTurnEvaluation: 'turn-evaluate',
 
   // webRTC
   webRTCIce: 'webrtc-ice',

--- a/src/hooks/socket/useChatSocket.ts
+++ b/src/hooks/socket/useChatSocket.ts
@@ -28,7 +28,11 @@ const useChatSocket = () => {
     emit(PUBLISH.sendChat, { data: { message } });
   };
 
-  return { emitSendChat };
+  const emitTurnEvaluation = (score: number, turn: number) => {
+    emit(PUBLISH.sendTurnEvaluation, { data: { score, turn } });
+  };
+
+  return { emitSendChat, emitTurnEvaluation };
 };
 
 export default useChatSocket;

--- a/src/redux/modules/gamePlaySlice.ts
+++ b/src/redux/modules/gamePlaySlice.ts
@@ -5,6 +5,7 @@ import { GameTimer, GameTurnInfoResponse } from '@customTypes/socketType';
 interface GamePlayStateType {
   playState?: GameTimer;
   turn?: GameTurnInfoResponse;
+  isTurnEvaluated?: boolean;
 }
 
 const initialState: GamePlayStateType = {};
@@ -23,10 +24,13 @@ const gamePlaySlice = createSlice({
       state.playState = undefined;
       state.turn = undefined;
     },
+    setEvaluated: (state, action: PayloadAction<boolean>) => {
+      state.isTurnEvaluated = action.payload;
+    },
   },
   extraReducers: {},
 });
 
-export const { setPlayState, setTurn, clearAllGamePlayState } = gamePlaySlice.actions;
+export const { setPlayState, setTurn, clearAllGamePlayState, setEvaluated } = gamePlaySlice.actions;
 
 export default gamePlaySlice;


### PR DESCRIPTION
### Issue

- resolves #95 

<br>

### 요약

게임에서 발표자의 발표 종료 직후 토론 시간에 플레이어들이 평가를 할 수 있다.



<br>

### 작업 내용

- 토론 시간에 발표자를 제외한 플레이어들은 채팅으로 [0~5] 점수를 입력해 발표자를 평가를 할 수 있다.

![eval](https://user-images.githubusercontent.com/76927397/215047045-edf83310-7a4f-4ff2-b641-6b6582621cae.gif)



- 평가는 하나의 turn에 한 번만 할 수 있도록 함

![eval](https://user-images.githubusercontent.com/76927397/215048330-c2408944-a302-483a-9241-e0c8fe32abf1.gif)


<br>

### 리뷰어에게 할 말

**모달로 안 한 이유**

- 평가는 자유인데 토론 시간 내내 평가할 때 까지 모달을 띄우면 사용자가 불편할 것 같다.
- 토론 시간에 자유롭게 대화 및 채팅하면서 편하게 원하는 시점에 평가를 간단하게 하는 것이 좋아보였다.



<br>


### ㄷ

- 이따 회의시간에 여쭤보고 모달로 하자고 하면 다시 되돌리겠습니다
 
