### PR TITLE
FEAT: 게임 페이지에서의 새로고침/뒤로가기 처리

### DIFF
--- a/src/components/home/EnterPrivateRoomModal.tsx
+++ b/src/components/home/EnterPrivateRoomModal.tsx
@@ -85,7 +85,7 @@ const EnterPrivateRoomModal = ({ visible, onClose, roomId, roomTitle, successHan
   };
 
   return (
-    <Modal visible={visible} onClose={onClose} title="ENTER THE ROOM">
+    <Modal visible={visible} onClose={onClose} title="ENTER THE ROOM" isBackgroundClickEventDisabled={true}>
       <EnterPrivateRoomModalLayout>
         <InputContainer label="방제">
           <RoomTitleBox>

--- a/src/hooks/useBeforeUnload.ts
+++ b/src/hooks/useBeforeUnload.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const useBeforeUnload = () => {
+  const preventClose = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    e.returnValue = '';
+  };
+
+  useEffect(() => {
+    (() => {
+      window.addEventListener('beforeunload', preventClose);
+    })();
+
+    return () => {
+      window.removeEventListener('beforeunload', preventClose);
+    };
+  }, []);
+};
+
+export default useBeforeUnload;

--- a/src/hooks/usePopState.ts
+++ b/src/hooks/usePopState.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const usePopState = () => {
+  const preventGoBack = () => {
+    history.pushState(null, '', location.href);
+  };
+
+  useEffect(() => {
+    (() => {
+      history.pushState(null, '', location.href);
+      window.addEventListener('popstate', preventGoBack);
+    })();
+
+    return () => {
+      window.removeEventListener('popstate', preventGoBack);
+    };
+  }, []);
+};
+
+export default usePopState;

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -8,7 +8,9 @@ import useErrorSocket from '@hooks/socket/useErrorSocket';
 import useGamePlaySocket from '@hooks/socket/useGamePlaySocket';
 import useGameSocket from '@hooks/socket/useGameSocket';
 import useGameUpdateSocket from '@hooks/socket/useGameUpdateSocket';
+import useBeforeUnload from '@hooks/useBeforeUnload';
 import useLocalStream from '@hooks/useLocalStream';
+import usePopState from '@hooks/usePopState';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
 import { addChat } from '@redux/modules/gameRoomSlice';
 import { alertToast } from '@utils/toast';
@@ -22,6 +24,7 @@ import EnterPrivateRoomModal from '@components/home/EnterPrivateRoomModal';
 import ContentContainer from '@components/layout/ContentContainer';
 import RoomTemplate from '@components/layout/RoomTemplate';
 
+// TODO: 컴포넌트 복잡도를 개선한다.
 const Room = () => {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -34,6 +37,8 @@ const Room = () => {
   const { emitUserLeaveRoom, emitJoinRoom, onJoinRoom } = useGameSocket();
   const { onError, offError } = useErrorSocket();
   useGamePlaySocket();
+  usePopState();
+  useBeforeUnload();
 
   const [isConfirmedUser, setIsConfirmedUser] = useState<boolean>(false);
   const [passwordModalVisible, setPasswordModalVisible] = useState<boolean>(false);

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -94,8 +94,6 @@ const Room = () => {
 
   const handlePasswordModalClose = () => {
     setPasswordModalVisible(false);
-    // TODO: beforeunload 이벤트 활용 또는 확인창 컴포넌트 구현해 적용
-    // TODO: 바깥을 클릭해도 안닫히게, 모달 주위를 어둡게
     navigate('/');
   };
 


### PR DESCRIPTION
### Issue

- resolves #94 

<br>

### 요약

게임 페이지에서 바로 뒤로가기나 새로고침을 시도하는 것이 어려워져야 한다.

**왜**

- 사용자가 잘못 누를 수도 있다. => 의도치 않은 게임 페이지에서의 이탈을 막고 나가기 버튼으로 나갈 수 있게 유도하는 것


<br>

### 작업 내용

- before unload hook 추가
- pop state hook 추가
- 게임페이지에 반영

<br>

![pr](https://user-images.githubusercontent.com/76927397/215059422-6421cd44-4182-4137-a458-75c567a314cd.gif)

 
