### PR TITLE
FIX: 게임 종료 후 처리에서 발생하는 문제 처리

### DIFF
--- a/src/components/game/GameReady.tsx
+++ b/src/components/game/GameReady.tsx
@@ -8,8 +8,8 @@ import useDebounce from '@hooks/useDebounce';
 import GameButton from '@components/common/GameButton';
 
 // TODO: 디자인을 반영해야 한다.
-const GameReady = () => {
-  const [isReady, setIsReady] = useState<boolean>(false);
+const GameReady = ({ readyState }: { readyState: boolean }) => {
+  const [isReady, setIsReady] = useState<boolean>(readyState);
   const [isRenderedFirstTime, setIsRenderedFirstTime] = useState<boolean>(true);
   const debouncedReadyState = useDebounce(isReady, 200);
   const { emitGameReady } = useGameInitiationSocket();

--- a/src/components/game/GameResultModal.tsx
+++ b/src/components/game/GameResultModal.tsx
@@ -40,14 +40,12 @@ const GameResultModal = ({ visible, onClose, participants, userId }: GameResultM
           <ul>
             {[...Array(6)].map((_, index) => {
               const height = sortedScore[index] === 0 ? 15 : sortedScore[index] ?? 10;
-              console.log(height);
               return (
-                <>
-                  <li
-                    id={'id-chart-' + index}
-                    key={index}
-                    style={{ height: ((height / maxScore) * 80).toString() + '%' }}
-                  />
+                <li
+                  id={'id-chart-' + index}
+                  key={index}
+                  style={{ height: ((height / maxScore) * 80).toString() + '%' }}
+                >
                   {sortedScore[index] !== undefined && (
                     <ReactTooltip anchorId={'id-chart-' + index} place={index === 0 ? 'right' : 'top'}>
                       <p style={{ fontSize: '18px', marginBottom: '10px' }}>
@@ -57,7 +55,7 @@ const GameResultModal = ({ visible, onClose, participants, userId }: GameResultM
                       <p style={{ fontSize: '16px' }}>&nbsp;{sortedParticipants[index].score + '점'}</p>
                     </ReactTooltip>
                   )}
-                </>
+                </li>
               );
             })}
           </ul>

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -48,7 +48,7 @@ const Presenter = () => {
       {!room?.isGameOn && (
         <GameReadyBox>
           {currentUser?.isHost && <GameStart />}
-          {currentUser?.isHost === false && <GameReady />}
+          {currentUser?.isHost === false && <GameReady readyState={currentUser.isReady} />}
         </GameReadyBox>
       )}
       {resultModalVisible && room && (

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -1,7 +1,7 @@
 import { SUBSCRIBE } from '@constants/socket';
 import useWebRTC from '@hooks/useWebRTC';
 import { useAppDispatch } from '@redux/hooks';
-import { addChat, updateRoom } from '@redux/modules/gameRoomSlice';
+import { addChat, updateEndedRoom, updateRoom } from '@redux/modules/gameRoomSlice';
 import { setPlayerList } from '@redux/modules/playerMediaSlice';
 
 import { GameRoomDetail } from '@customTypes/gameRoomType';
@@ -33,11 +33,14 @@ const useGameUpdateSocket = () => {
         data: {
           room: GameRoomDetail;
           eventUserInfo: EventUserInfo;
-          event: 'enter' | 'leave' | 'leave-force' | 'ready' | 'start';
+          event: 'enter' | 'leave' | 'leave-force' | 'ready' | 'start' | 'game-end';
         };
       }) => {
         console.log('[on] update-room');
-        console.log(data);
+        if (data.event === 'game-end') {
+          dispatch(updateEndedRoom);
+          return;
+        }
         const { nickname, socketId, userId } = data.eventUserInfo;
         dispatch(updateRoom(data.room));
         dispatch(setPlayerList(data.room.participants));

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -12,7 +12,7 @@ import useBeforeUnload from '@hooks/useBeforeUnload';
 import useLocalStream from '@hooks/useLocalStream';
 import usePopState from '@hooks/usePopState';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
-import { addChat } from '@redux/modules/gameRoomSlice';
+import { addChat, updateRoom } from '@redux/modules/gameRoomSlice';
 import { alertToast } from '@utils/toast';
 
 import CamList from '@components/game/CamList';
@@ -54,6 +54,7 @@ const Room = () => {
       emitUserLeaveRoom();
       offError();
       userStreamRef && destroyLocalStream(userStreamRef);
+      dispatch(updateRoom(null));
       console.log('[destroy] local stream');
     };
   }, []);

--- a/src/redux/modules/gameRoomSlice.ts
+++ b/src/redux/modules/gameRoomSlice.ts
@@ -68,6 +68,15 @@ const gameRoomSlice = createSlice({
       });
       state.room = { ...state.room, participants };
     },
+    updateEndedRoom: (state) => {
+      if (!state.room) {
+        return;
+      }
+      const participants = state.room.participants.map((participant) => {
+        return { ...participant, isReady: false };
+      });
+      state.room = { ...state.room, isGameOn: false, isGameReadyToStart: false, participants };
+    },
   },
   extraReducers: {},
 });
@@ -82,6 +91,7 @@ export const {
   setIsGameOnState,
   setScore,
   clearScore,
+  updateEndedRoom,
 } = gameRoomSlice.actions;
 
 export default gameRoomSlice;


### PR DESCRIPTION
### Issue

- resolves #108 

<br>

### 요약
게임 종료 후 처리에서 발생하는 문제를 처리

<br>

### 작업 내용

- `GameResultModal에서 루프돌며 그래프 그릴 때 key 누락된 부분 수정
- room page 이탈 시 room상태 clean up
- update-room 이벤트를 받을 때 `game-end`에 대한 room 상태를 별도로 반영하도록 함
- ready 컴포넌트 수정

<br>

### 뻘짓

**게임 페이지를 이탈해도 게임 room 전역 상태가 그대로 남는 문제~~이걸이제보다니..~~**

![room1](https://user-images.githubusercontent.com/76927397/215291368-993b0623-e3c5-4f6b-9665-828902017a0f.gif)

**cleanup 넣어서 unmount 시 초기화되도록 해결**

![room2](https://user-images.githubusercontent.com/76927397/215291374-0de02dfb-eaf3-4000-9256-6a78800541bf.gif)




<br>

### 리뷰어에게 할 말

- 해결하고 또 해결해도 에러는 있네요  이래서 처음부터 아예 잘 생각하고개발해야되나봅니다 ㅎㅎ
 
