### PR TITLE
FEAT: 게임 종료 시 스코어 관련 처리 추가하기 

### DIFF
--- a/src/components/character/CatScore.tsx
+++ b/src/components/character/CatScore.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import ScoreLarge from '@assets/img_scoreLarge.png';
 import ScoreSmall from '@assets/img_scoreSmall.png';
+import { useAppSelector } from '@redux/hooks';
 
 export interface CatScoreProps {
   scoreInfo?: {
@@ -15,6 +16,8 @@ export interface CatScoreProps {
 const CatScore = ({ scoreInfo, size = 'small' }: CatScoreProps) => {
   const [totalScore, setTotalScore] = useState<number>(0);
   const [restScore, setRestScore] = useState<number>(0);
+  const { scoreMap } = useAppSelector((state) => state.gameRoom);
+
   useEffect(() => {
     if (!scoreInfo?.score) {
       return;
@@ -34,6 +37,13 @@ const CatScore = ({ scoreInfo, size = 'small' }: CatScoreProps) => {
       clearTimeout(timeoutId);
     };
   }, [restScore]);
+
+  useEffect(() => {
+    if (Object.keys(scoreMap).length === 0) {
+      setTotalScore(0);
+      setRestScore(0);
+    }
+  }, [scoreMap]);
 
   return (
     <CatScoreLayout size={size}>

--- a/src/components/game/GameReady.tsx
+++ b/src/components/game/GameReady.tsx
@@ -8,7 +8,7 @@ import useDebounce from '@hooks/useDebounce';
 import GameButton from '@components/common/GameButton';
 
 // TODO: 디자인을 반영해야 한다.
-const GameReady = ({ readyState }: { readyState: boolean }) => {
+const GameReady = () => {
   const [isReady, setIsReady] = useState<boolean>(false);
   const [isRenderedFirstTime, setIsRenderedFirstTime] = useState<boolean>(true);
   const debouncedReadyState = useDebounce(isReady, 200);
@@ -21,10 +21,6 @@ const GameReady = ({ readyState }: { readyState: boolean }) => {
     }
     emitGameReady();
   }, [debouncedReadyState]);
-
-  useEffect(() => {
-    setIsReady(readyState);
-  }, [readyState]);
 
   return (
     <GameReadyLayout>

--- a/src/components/game/GameResultBarChart.tsx
+++ b/src/components/game/GameResultBarChart.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import styled, { keyframes } from 'styled-components';
 
 import { getCatInfoByQuery } from '@utils/character';
@@ -17,6 +19,15 @@ interface GameResultCharBarProps {
 
 const GameResultBarChart = ({ maxScore, score, participant, index }: GameResultCharBarProps) => {
   const height = score === 0 ? 15 : score ?? 10;
+  const [scoreInfo, setScoreInfo] = useState<{ score: number }>({ score: 0 });
+
+  useEffect(() => {
+    if (score === scoreInfo.score) {
+      return;
+    }
+    setScoreInfo({ score: score });
+  }, [score]);
+
   const { cat, rocket } = getCatInfoByQuery(participant?.profileImg);
   return (
     <GameResultBarChartLayout
@@ -30,7 +41,7 @@ const GameResultBarChart = ({ maxScore, score, participant, index }: GameResultC
               rocketTheme={rocket}
               scale={1.34}
               size="large"
-              scoreInfo={{ score: participant.score }}
+              scoreInfo={scoreInfo}
               nickname={participant.nickname}
               hasIdlePopupAnimation={false}
               catType="body"

--- a/src/components/game/GameResultModal.tsx
+++ b/src/components/game/GameResultModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import styled from 'styled-components';
@@ -17,17 +17,20 @@ export interface GameResultModalProps {
   visible: boolean;
   onClose: () => void;
   participants: Participant[];
+  scoreMap: { [key: number]: number };
   userId: number;
 }
 
-const GameResultModal = ({ visible, onClose, participants, userId }: GameResultModalProps) => {
+const GameResultModal = ({ visible, onClose, participants, scoreMap, userId }: GameResultModalProps) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const sortedParticipants = [...participants].sort((o1, o2) => o2.score - o1.score);
-  const sortedScore = sortedParticipants.map((participant) => participant.score);
-  const maxScore = sortedScore[0];
+  const [sortedParticipants, setSortedParticipants] = useState<Participant[]>([]);
+  const [sortedScore, setSortedScore] = useState<number[]>([]);
   userId;
   useEffect(() => {
+    const sorted = [...participants].sort((o1, o2) => scoreMap[o2.userId] - scoreMap[o1.userId]);
+    setSortedParticipants(sorted);
+    setSortedScore(sorted.map((participant) => scoreMap[participant.userId]));
     return () => {
       dispatch(clearScore());
     };
@@ -41,37 +44,37 @@ const GameResultModal = ({ visible, onClose, participants, userId }: GameResultM
           <ul>
             <GameResultBarChart
               index={4}
-              maxScore={maxScore}
+              maxScore={sortedScore[0]}
               score={sortedScore[4]}
               participant={sortedParticipants[4]}
             />
             <GameResultBarChart
               index={2}
-              maxScore={maxScore}
+              maxScore={sortedScore[0]}
               score={sortedScore[2]}
               participant={sortedParticipants[2]}
             />
             <GameResultBarChart
               index={0}
-              maxScore={maxScore}
+              maxScore={sortedScore[0]}
               score={sortedScore[0]}
               participant={sortedParticipants[0]}
             />
             <GameResultBarChart
               index={1}
-              maxScore={maxScore}
+              maxScore={sortedScore[0]}
               score={sortedScore[1]}
               participant={sortedParticipants[1]}
             />
             <GameResultBarChart
               index={3}
-              maxScore={maxScore}
+              maxScore={sortedScore[0]}
               score={sortedScore[3]}
               participant={sortedParticipants[3]}
             />
             <GameResultBarChart
               index={5}
-              maxScore={maxScore}
+              maxScore={sortedScore[0]}
               score={sortedScore[5]}
               participant={sortedParticipants[5]}
             />

--- a/src/components/game/GameResultModal.tsx
+++ b/src/components/game/GameResultModal.tsx
@@ -21,12 +21,13 @@ export interface GameResultModalProps {
   userId: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const GameResultModal = ({ visible, onClose, participants, scoreMap, userId }: GameResultModalProps) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [sortedParticipants, setSortedParticipants] = useState<Participant[]>([]);
   const [sortedScore, setSortedScore] = useState<number[]>([]);
-  userId;
+
   useEffect(() => {
     const sorted = [...participants].sort((o1, o2) => scoreMap[o2.userId] - scoreMap[o1.userId]);
     setSortedParticipants(sorted);

--- a/src/components/game/PlayerCat.tsx
+++ b/src/components/game/PlayerCat.tsx
@@ -8,19 +8,19 @@ import CatOnGame from '@components/character/CatOnGame';
 
 import { Participant } from '@customTypes/gameRoomType';
 
-const PlayerCat = ({ participant }: { participant: Participant }) => {
+const PlayerCat = ({ participant, playerScore }: { participant: Participant; playerScore: number }) => {
   const { cat, rocket } = getCatInfoByQuery(participant.profileImg);
   const [score, setScore] = useState<{ score: number }>({ score: 0 });
 
   useEffect(() => {
-    if (!participant.score || score.score === participant.score) {
+    if (!playerScore || score.score === playerScore) {
       return;
     }
-    setScore({ score: participant.score - score.score });
-  }, [participant]);
+    setScore({ score: playerScore - score.score });
+  }, [playerScore]);
 
   return (
-    <PlayerCatLayout score={participant.score} isReady={participant.isHost ? true : participant.isReady ? true : false}>
+    <PlayerCatLayout score={playerScore} isReady={participant.isHost ? true : participant.isReady ? true : false}>
       <div>
         <CatOnGame
           catTheme={cat}

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -13,7 +13,7 @@ import PresenterCam from './PresenterCam';
 
 const Presenter = () => {
   const { user } = useAppSelector((state) => state.user);
-  const { room } = useAppSelector((state) => state.gameRoom);
+  const { room, scoreMap } = useAppSelector((state) => state.gameRoom);
   const { turn, playState } = useAppSelector((state) => state.gamePlay);
   const [resultModalVisible, setResultModalVisible] = useState<boolean>(false);
   const currentUser = room?.participants.find((participant) => participant.userId === user?.userId);
@@ -48,7 +48,7 @@ const Presenter = () => {
       {!room?.isGameOn && (
         <GameReadyBox>
           {currentUser?.isHost && <GameStart />}
-          {currentUser?.isHost === false && <GameReady readyState={currentUser.isReady} />}
+          {currentUser?.isHost === false && <GameReady />}
         </GameReadyBox>
       )}
       {resultModalVisible && room && (
@@ -56,6 +56,7 @@ const Presenter = () => {
           visible={resultModalVisible}
           onClose={() => setResultModalVisible(false)}
           participants={room.participants}
+          scoreMap={scoreMap}
           userId={user?.userId as number}
         />
       )}

--- a/src/components/game/ScoreBoard.tsx
+++ b/src/components/game/ScoreBoard.tsx
@@ -8,8 +8,7 @@ import StarlightBackground from '@components/common/StarlightBackground';
 import PlayerCat from './PlayerCat';
 
 const ScoreBoard = () => {
-  const { room } = useAppSelector((state) => state.gameRoom);
-
+  const { room, scoreMap } = useAppSelector((state) => state.gameRoom);
   if (!room) {
     return <ScoreBoardLayout></ScoreBoardLayout>;
   }
@@ -18,7 +17,7 @@ const ScoreBoard = () => {
       <StarlightBackground />
       <PlayerCatBox>
         {room.participants.map((participant) => (
-          <PlayerCat key={participant.socketId} participant={participant} />
+          <PlayerCat key={participant.socketId} participant={participant} playerScore={scoreMap[participant.userId]} />
         ))}
       </PlayerCatBox>
     </ScoreBoardLayout>

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -12,6 +12,7 @@ import useBeforeUnload from '@hooks/useBeforeUnload';
 import useLocalStream from '@hooks/useLocalStream';
 import usePopState from '@hooks/usePopState';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { clearAllGamePlayState } from '@redux/modules/gamePlaySlice';
 import { addChat, updateRoom } from '@redux/modules/gameRoomSlice';
 import { alertToast } from '@utils/toast';
 
@@ -55,6 +56,7 @@ const Room = () => {
       offError();
       userStreamRef && destroyLocalStream(userStreamRef);
       dispatch(updateRoom(null));
+      dispatch(clearAllGamePlayState());
       console.log('[destroy] local stream');
     };
   }, []);

--- a/src/redux/modules/gameRoomSlice.ts
+++ b/src/redux/modules/gameRoomSlice.ts
@@ -13,6 +13,7 @@ interface InitialGameRoomStateType {
     roomId: number;
     password?: number;
   };
+  scoreMap: { [key: number]: number };
 }
 
 const initialState: InitialGameRoomStateType = {
@@ -20,6 +21,7 @@ const initialState: InitialGameRoomStateType = {
   broadcastedRooms: [],
   chatList: [],
   lastEnteredRoom: storage.getCurrentEnteredRoom(),
+  scoreMap: {},
 };
 
 const gameRoomSlice = createSlice({
@@ -50,23 +52,13 @@ const gameRoomSlice = createSlice({
       state.room = { ...(state.room as GameRoomDetail), isGameOn: action.payload };
     },
     setScore: (state, action: PayloadAction<{ userId: number; score: number }>) => {
-      const { userId, score } = action.payload;
-      if (!state.room?.participants) {
-        return;
-      }
-      const participants = state.room.participants.map((participant) =>
-        participant.userId === userId ? { ...participant, score: (participant.score ?? 0) + score } : participant,
-      );
-      state.room = { ...state.room, participants };
+      state.scoreMap = {
+        ...state.scoreMap,
+        [action.payload.userId]: (state.scoreMap[action.payload.userId] ?? 0) + action.payload.score,
+      };
     },
     clearScore: (state) => {
-      if (!state.room?.participants) {
-        return;
-      }
-      const participants = state.room.participants.map((participant) => {
-        return { ...participant, score: 0 };
-      });
-      state.room = { ...state.room, participants };
+      state.scoreMap = {};
     },
   },
   extraReducers: {},

--- a/src/stories/game/GameResultModal.stories.tsx
+++ b/src/stories/game/GameResultModal.stories.tsx
@@ -27,12 +27,20 @@ const Template: ComponentStory<typeof GameResultModal> = (args: GameResultModalP
 export const Default = Template.bind({});
 Default.args = {
   participants: [
-    { nickname: '한글은여섯개', isReady: true, userId: 1, socketId: '', profileImg: '', score: 150 },
-    { nickname: '여섯글자가넘으면어떡해', isReady: true, userId: 2, socketId: '', profileImg: 'brown-red', score: 60 },
-    { nickname: 'Helloworld', isReady: true, userId: 3, socketId: '', profileImg: 'black-blue', score: 240 },
-    { nickname: 'ehd0309박동석123', isReady: true, userId: 4, socketId: '', profileImg: 'gray-red', score: 420 },
-    { nickname: '컴퓨터텔레비죤', isReady: true, userId: 5, socketId: '', profileImg: 'mix-yellow', score: 680 },
-    { nickname: '콜라', isReady: true, userId: 6, socketId: '', profileImg: 'orange-red', score: 20 },
+    { nickname: '한글은여섯개', isReady: true, userId: 1, socketId: '', profileImg: '' },
+    { nickname: '여섯글자가넘으면어떡해', isReady: true, userId: 2, socketId: '', profileImg: 'brown-red' },
+    { nickname: 'Helloworld', isReady: true, userId: 3, socketId: '', profileImg: 'black-blue' },
+    { nickname: 'ehd0309박동석123', isReady: true, userId: 4, socketId: '', profileImg: 'gray-red' },
+    { nickname: '컴퓨터텔레비죤', isReady: true, userId: 5, socketId: '', profileImg: 'mix-yellow' },
+    { nickname: '콜라', isReady: true, userId: 6, socketId: '', profileImg: 'orange-red' },
   ],
+  scoreMap: {
+    [1]: 240,
+    [2]: 150,
+    [3]: 450,
+    [4]: 60,
+    [5]: 90,
+    [6]: 100,
+  },
   userId: 1,
 };

--- a/src/types/gameRoomType.ts
+++ b/src/types/gameRoomType.ts
@@ -27,7 +27,6 @@ export interface Participant {
   audio?: boolean;
   video?: boolean;
   isHost?: boolean;
-  score: number;
 }
 
 export interface ChatBaseType {


### PR DESCRIPTION
### Issue

- resolves #116 

<br>

### 요약

게임 종료 시 게임 페이지 스코어 관련 처리

<br>

### 작업 내용

- 게임이 종료되면 게임방은 대기상태가 되고 레디가 풀린다.
- participants의 속성으로 있던 score를 scoreMap으로 따로 상태로 분리하여 처리
- 게임 종료 시 결과 모달의 스코어가 표시된다.
- 결과 모달이 닫힐 경우 게임 페이지 스코어 보드의 점수가 초기화 된다.


 
