### PR TITLE
FEAT: 중복 로그인 처리 추가

### DIFF
--- a/src/hooks/useDuplicatedUserInvalidate.ts
+++ b/src/hooks/useDuplicatedUserInvalidate.ts
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+
+import { useAppDispatch } from '@redux/hooks';
+import { logout } from '@redux/modules/userSlice';
+import { alertToast } from '@utils/toast';
+
+const useDuplicatedUserInvalidate = () => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const invalidate = () => {
+    alertToast('다른 기기 또는 브라우저에서 로그인하여 자동으로 로그아웃 되었습니다.', 'info', {
+      hideProgressBar: true,
+      autoClose: false,
+    });
+    dispatch(logout());
+    navigate('/', { replace: true });
+  };
+
+  return { invalidate };
+};
+
+export default useDuplicatedUserInvalidate;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { PUBLISH } from '@constants/socket';
 import useErrorSocket from '@hooks/socket/useErrorSocket';
+import useDuplicatedUserInvalidate from '@hooks/useDuplicatedUserInvalidate';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
 import { logout } from '@redux/modules/userSlice';
 
@@ -15,9 +15,13 @@ const Main = () => {
   const user = useAppSelector((state) => state.user.user);
   const dispatch = useAppDispatch();
   const { onError, offError } = useErrorSocket();
+  const { invalidate } = useDuplicatedUserInvalidate();
 
   useEffect(() => {
-    onError([{ target: 'event', value: PUBLISH.login, callback: () => dispatch(logout()) }]);
+    onError([
+      { target: 'status', value: 401, callback: () => dispatch(logout()) },
+      { target: 'status', value: 409, callback: invalidate, skipAlert: true },
+    ]);
     return () => {
       offError();
     };

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -9,6 +9,7 @@ import useGamePlaySocket from '@hooks/socket/useGamePlaySocket';
 import useGameSocket from '@hooks/socket/useGameSocket';
 import useGameUpdateSocket from '@hooks/socket/useGameUpdateSocket';
 import useBeforeUnload from '@hooks/useBeforeUnload';
+import useDuplicatedUserInvalidate from '@hooks/useDuplicatedUserInvalidate';
 import useLocalStream from '@hooks/useLocalStream';
 import usePopState from '@hooks/usePopState';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
@@ -37,6 +38,7 @@ const Room = () => {
   const { onAnnounceRoomUpdate, offAnnounceRoomUpdate } = useGameUpdateSocket();
   const { emitUserLeaveRoom, emitJoinRoom, onJoinRoom } = useGameSocket();
   const { onError, offError } = useErrorSocket();
+  const { invalidate } = useDuplicatedUserInvalidate();
   useGamePlaySocket();
   usePopState();
   useBeforeUnload();
@@ -96,6 +98,7 @@ const Room = () => {
             dispatch(addChat({ message: msg as string, nickname: '', type: 'warning', socketId: '', userId: 0 })),
           skipAlert: true,
         },
+        { target: 'status', value: 409, callback: invalidate, skipAlert: true },
       ]);
     }
   }, [id, authorized, isConfirmedUser]);


### PR DESCRIPTION
### Issue

- resolves #119 

<br>

### 요약

중복 로그인 이벤트  처리 추가

<br>

### 작업 내용

- 중복 로그인 시 기존 사용자 브라우저의 로그인 상태를 만료시키고 메인페이지로 보낸다.

<br>

![log2](https://user-images.githubusercontent.com/76927397/216115579-9cd30f7b-74bd-4c31-8c64-65db1b563ed8.gif)

![log1](https://user-images.githubusercontent.com/76927397/216115593-d32e29c3-9009-4d99-9053-ca4b708415b8.gif)

 
