### PR TITLE
FEAT: READY/START UI 개선 

### DIFF
--- a/src/components/common/GameButton.tsx
+++ b/src/components/common/GameButton.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import Button from './Button';
 
-interface GameButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface GameButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   visible: boolean;
 }
@@ -23,7 +23,7 @@ const GameButtonLayout = styled(Button)<{ visible: boolean }>`
   text-shadow: none;
   background-image: linear-gradient(
     0deg,
-    ${(props) => props.theme.colors.purple2} 50%,
+    ${(props) => (props.visible ? props.theme.colors.purple2 : '#A1A1A1')} 50%,
     ${(props) => props.theme.colors.white1} 50%
   );
   background-size: 100%;
@@ -31,7 +31,6 @@ const GameButtonLayout = styled(Button)<{ visible: boolean }>`
   -webkit-text-fill-color: transparent;
   -webkit-background-clip: text;
   -webkit-text-stroke: 1px ${(props) => props.theme.colors.black1};
-  opacity: ${(props) => (props.visible ? 1 : 0.3)};
   width: 328px;
   height: 72px;
 `;

--- a/src/components/game/GameReady.tsx
+++ b/src/components/game/GameReady.tsx
@@ -24,10 +24,11 @@ const GameReady = ({ handleClick }: { handleClick: () => void }) => {
   return (
     <GameButtonContainer>
       <DescriptionTextBox>
-        <p>게임을 시작해볼까요?</p> 시작을 원하시면 아래 버튼을 눌러주세요
+        <p>게임을 시작해볼까요?</p>
+        <p>{debouncedReadyState ? '다른 참가자들울 잠시 기다려주세요!' : '시작을 원하시면 레디 버튼을 눌러주세요'}</p>
       </DescriptionTextBox>
-      <GameReadyButton visible={!isReady} onClick={() => setIsReady(!isReady)}>
-        READY
+      <GameReadyButton visible={!debouncedReadyState} onClick={() => setIsReady(!isReady)}>
+        {debouncedReadyState ? 'CANCEL' : 'READY'}
       </GameReadyButton>
     </GameButtonContainer>
   );
@@ -37,6 +38,7 @@ const DescriptionTextBox = styled.div`
   text-align: left;
   font-size: 24px;
   line-height: 120%;
+  width: 456px;
   color: ${(props) => props.theme.colors.ivory1};
 `;
 

--- a/src/components/game/GameReady.tsx
+++ b/src/components/game/GameReady.tsx
@@ -6,6 +6,7 @@ import useGameInitiationSocket from '@hooks/socket/useGameInitiationSocket';
 import useDebounce from '@hooks/useDebounce';
 
 import GameButton from '@components/common/GameButton';
+import GameButtonContainer from '@components/layout/GameButtonContainer';
 
 // TODO: 디자인을 반영해야 한다.
 const GameReady = () => {
@@ -23,22 +24,22 @@ const GameReady = () => {
   }, [debouncedReadyState]);
 
   return (
-    <GameReadyLayout>
+    <GameButtonContainer>
+      <DescriptionTextBox>
+        <p>게임을 시작해볼까요?</p> 시작을 원하시면 아래 버튼을 눌러주세요
+      </DescriptionTextBox>
       <GameReadyButton visible={!isReady} onClick={() => setIsReady(!isReady)}>
         READY
       </GameReadyButton>
-    </GameReadyLayout>
+    </GameButtonContainer>
   );
 };
 
-const GameReadyLayout = styled.div`
-  background-color: ${(props) => props.theme.colors.darkGrey2};
-  width: 628px;
-  height: 232px;
-  border: ${(props) => props.theme.borders.normal1};
-  display: flex;
-  justify-content: center;
-  align-items: center;
+const DescriptionTextBox = styled.div`
+  text-align: left;
+  font-size: 24px;
+  line-height: 120%;
+  color: ${(props) => props.theme.colors.ivory1};
 `;
 
 const GameReadyButton = styled(GameButton)``;

--- a/src/components/game/GameReady.tsx
+++ b/src/components/game/GameReady.tsx
@@ -2,25 +2,23 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import useGameInitiationSocket from '@hooks/socket/useGameInitiationSocket';
 import useDebounce from '@hooks/useDebounce';
 
 import GameButton from '@components/common/GameButton';
 import GameButtonContainer from '@components/layout/GameButtonContainer';
 
 // TODO: 디자인을 반영해야 한다.
-const GameReady = () => {
+const GameReady = ({ handleClick }: { handleClick: () => void }) => {
   const [isReady, setIsReady] = useState<boolean>(false);
   const [isRenderedFirstTime, setIsRenderedFirstTime] = useState<boolean>(true);
   const debouncedReadyState = useDebounce(isReady, 200);
-  const { emitGameReady } = useGameInitiationSocket();
 
   useEffect(() => {
     if (isRenderedFirstTime) {
       setIsRenderedFirstTime(false);
       return;
     }
-    emitGameReady();
+    handleClick();
   }, [debouncedReadyState]);
 
   return (

--- a/src/components/game/GameStart.tsx
+++ b/src/components/game/GameStart.tsx
@@ -2,17 +2,15 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import useGameInitiationSocket from '@hooks/socket/useGameInitiationSocket';
 import { useAppSelector } from '@redux/hooks';
 
 import GameButton from '@components/common/GameButton';
 import GameButtonContainer from '@components/layout/GameButtonContainer';
 
 // TODO: 디자인을 반영해야 한다.
-const GameStart = () => {
+const GameStart = ({ handleClick }: { handleClick: () => void }) => {
   const [isGameReadyToStart, setIsGameReadyToStart] = useState<boolean>(false);
   const { room } = useAppSelector((state) => state.gameRoom);
-  const { emitGameStart } = useGameInitiationSocket();
 
   useEffect(() => {
     if (room?.participants.length === 1) {
@@ -27,7 +25,7 @@ const GameStart = () => {
       <DescriptionTextBox>
         <p>게임을 시작해볼까요?</p> 시작을 원하시면 아래 버튼을 눌러주세요
       </DescriptionTextBox>
-      <GameStartButton onClick={emitGameStart} disabled={!isGameReadyToStart} visible={isGameReadyToStart}>
+      <GameStartButton onClick={handleClick} disabled={!isGameReadyToStart} visible={isGameReadyToStart}>
         START
       </GameStartButton>
     </GameButtonContainer>

--- a/src/components/game/GameStart.tsx
+++ b/src/components/game/GameStart.tsx
@@ -6,6 +6,7 @@ import useGameInitiationSocket from '@hooks/socket/useGameInitiationSocket';
 import { useAppSelector } from '@redux/hooks';
 
 import GameButton from '@components/common/GameButton';
+import GameButtonContainer from '@components/layout/GameButtonContainer';
 
 // TODO: 디자인을 반영해야 한다.
 const GameStart = () => {
@@ -22,26 +23,26 @@ const GameStart = () => {
   }, [isGameReadyToStart, room]);
 
   return (
-    <GameStartLayout>
+    <GameButtonContainer>
+      <DescriptionTextBox>
+        <p>게임을 시작해볼까요?</p> 시작을 원하시면 아래 버튼을 눌러주세요
+      </DescriptionTextBox>
       <GameStartButton onClick={emitGameStart} disabled={!isGameReadyToStart} visible={isGameReadyToStart}>
         START
       </GameStartButton>
-    </GameStartLayout>
+    </GameButtonContainer>
   );
 };
 
-const GameStartLayout = styled.div`
-  background-color: ${(props) => props.theme.colors.darkGrey2};
-  width: 628px;
-  height: 232px;
-  border: ${(props) => props.theme.borders.normal1};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
 const GameStartButton = styled(GameButton)`
   ${(props) => !props.visible && `cursor: not-allowed;`}
+`;
+
+const DescriptionTextBox = styled.div`
+  text-align: left;
+  font-size: 24px;
+  line-height: 120%;
+  color: ${(props) => props.theme.colors.ivory1};
 `;
 
 export default GameStart;

--- a/src/components/game/GameStart.tsx
+++ b/src/components/game/GameStart.tsx
@@ -23,23 +23,32 @@ const GameStart = ({ handleClick }: { handleClick: () => void }) => {
   return (
     <GameButtonContainer>
       <DescriptionTextBox>
-        <p>게임을 시작해볼까요?</p> 시작을 원하시면 아래 버튼을 눌러주세요
+        <p>게임을 시작해볼까요?</p>
+        <p>
+          {isGameReadyToStart
+            ? '시작을 원하시면 아래 버튼을 눌러주세요'
+            : room?.participants.length === 1
+            ? '아직 같이 할 사람이 없어요!'
+            : '다른 참가자들이 준비중입니다..'}
+        </p>
       </DescriptionTextBox>
       <GameStartButton onClick={handleClick} disabled={!isGameReadyToStart} visible={isGameReadyToStart}>
-        START
+        {isGameReadyToStart || room?.participants.length === 1 ? 'START' : 'WAIT'}
       </GameStartButton>
     </GameButtonContainer>
   );
 };
 
 const GameStartButton = styled(GameButton)`
-  ${(props) => !props.visible && `cursor: not-allowed;`}
+  ${(props) => !props.visible && `cursor: default;`};
+  opacity: ${(props) => (props.visible ? 1 : 0.7)};
 `;
 
 const DescriptionTextBox = styled.div`
   text-align: left;
   font-size: 24px;
   line-height: 120%;
+  width: 456px;
   color: ${(props) => props.theme.colors.ivory1};
 `;
 

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import styled, { keyframes } from 'styled-components';
 
+import useGameInitiationSocket from '@hooks/socket/useGameInitiationSocket';
 import { useAppSelector } from '@redux/hooks';
 import { filterKeyword } from '@utils/common';
 
@@ -16,6 +17,7 @@ const Presenter = () => {
   const { room, scoreMap } = useAppSelector((state) => state.gameRoom);
   const { turn, playState } = useAppSelector((state) => state.gamePlay);
   const [resultModalVisible, setResultModalVisible] = useState<boolean>(false);
+  const { emitGameReady, emitGameStart } = useGameInitiationSocket();
   const currentUser = room?.participants.find((participant) => participant.userId === user?.userId);
   const presenterNickname =
     room?.participants.find((participant) => participant.userId === turn?.speechPlayer)?.nickname ?? '';
@@ -47,8 +49,8 @@ const Presenter = () => {
       {room?.isGameOn && turn && <PresenterCam nickname={presenterNickname} isMe={isMe} userId={turn.speechPlayer} />}
       {!room?.isGameOn && (
         <GameReadyBox>
-          {currentUser?.isHost && <GameStart />}
-          {currentUser?.isHost === false && <GameReady />}
+          {currentUser?.isHost && <GameStart handleClick={emitGameStart} />}
+          {currentUser?.isHost === false && <GameReady handleClick={emitGameReady} />}
         </GameReadyBox>
       )}
       {resultModalVisible && room && (

--- a/src/components/layout/GameButtonContainer.tsx
+++ b/src/components/layout/GameButtonContainer.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+const GameButtonContainer = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <GameButtonContainerLayout>
+      <GameButtonContainerHeaderBox />
+      <GameButtonContainerContentBox>{children}</GameButtonContainerContentBox>
+    </GameButtonContainerLayout>
+  );
+};
+
+const GameButtonContainerLayout = styled.div`
+  background-color: ${(props) => props.theme.colors.darkGrey2};
+  width: 628px;
+  height: 312px;
+  box-shadow: ${(props) => props.theme.boxShadows.boxShadow1};
+  border: ${(props) => props.theme.borders.normal1};
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  flex-direction: column;
+  z-index: 100;
+`;
+
+const GameButtonContainerHeaderBox = styled.div`
+  font-family: ${(props) => props.theme.font.joystick};
+  font-size: 24px;
+  color: ${(props) => props.theme.colors.black1};
+  height: 42px;
+  width: 100%;
+  background-color: ${(props) => props.theme.colors.lightGrey6};
+  box-shadow: 2px 0px ${(props) => props.theme.colors.ivory1}, -2px -2px ${(props) => props.theme.colors.ivory1};
+`;
+
+const GameButtonContainerContentBox = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  grid-row-gap: 32px;
+`;
+
+export default GameButtonContainer;

--- a/src/stories/common/GameButton.stories.tsx
+++ b/src/stories/common/GameButton.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import GameButton, { GameButtonProps } from '@components/common/GameButton';
+
+export default {
+  title: 'common/GameButton',
+  component: GameButton,
+} as ComponentMeta<typeof GameButton>;
+
+const Template: ComponentStory<typeof GameButton> = (args: GameButtonProps) => {
+  return <GameButton {...args}>HELLO</GameButton>;
+};
+
+export const Default = Template.bind({});

--- a/src/stories/game/GameReady.stories.tsx
+++ b/src/stories/game/GameReady.stories.tsx
@@ -1,0 +1,25 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import GameReady from '@components/game/GameReady';
+
+export default {
+  title: 'game/GameReady',
+  component: GameReady,
+  parameters: {
+    controls: {
+      exclude: ['handleClick'],
+    },
+  },
+} as ComponentMeta<typeof GameReady>;
+
+const Template: ComponentStory<typeof GameReady> = () => {
+  return (
+    <GameReady
+      handleClick={() => {
+        //
+      }}
+    />
+  );
+};
+
+export const Default = Template.bind({});


### PR DESCRIPTION
### Issue

- resolves #120

<br>

### 요약

게임 페이지의 레디/스타트 UI를 디자인에 맞게 개선한다.



<br>

### 작업 내용

- Game ready, start를 위한 레이아웃 분리해서 추가
- Game ready, start 버튼 상태에 따라 UI및 설명글 변경되도록 추가

<br>

![btn](https://user-images.githubusercontent.com/76927397/216145508-3ead91e4-c15e-4ca7-88a8-676bf3f1843c.gif)

<br>

### 리뷰어에게 할 말

- 설명글 괜찮나요?

<br>


 
