### PR TITLE
FEAT: 회원정보 수정 기능 추가

### DIFF
--- a/src/apis/userApi.ts
+++ b/src/apis/userApi.ts
@@ -10,7 +10,10 @@ const userApi = {
   // 회원 키워드 조회
   getUserKeyword: () => authInstance.get<never, MyKeywordsResponse>(USER_API + '/me/keyword'),
   // 닉네임 중복 검사
-  duplicateCheck: (newNickname: string) => noAuthInstance.get(USER_API + `/nickname?nickname=${newNickname}`),
+  duplicateCheck: (newNickname: string) => noAuthInstance.get(USER_API + `/${newNickname}`),
+  // 회원 정보 수정
+  updateUserInfo: ({ newNickname, newProfileImg }: { newNickname: string; newProfileImg: string }) =>
+    authInstance.patch(USER_API + '/me', { nickname: newNickname, profileImg: newProfileImg }),
   // 로그아웃
   logout: () => authInstance.get(USER_API + '/logout'),
 };

--- a/src/components/home/SetUpInfoModal.tsx
+++ b/src/components/home/SetUpInfoModal.tsx
@@ -15,7 +15,7 @@ const SetUpInfoModal = ({ visible, onClose, mypage }: { visible: boolean; onClos
       width={!isSetUpInfoSuccess ? 1020 : undefined}
     >
       {!isSetUpInfoSuccess ? (
-        <SetUpInfo />
+        <SetUpInfo isSetUpInfoSuccess={setIsSetUpInfoSuccess} onClose={onClose} mypage={mypage} />
       ) : (
         <SetUpInfoSuccess isSetUpInfoSuccess={setIsSetUpInfoSuccess} onClose={onClose} />
       )}

--- a/src/components/home/UserInfo.tsx
+++ b/src/components/home/UserInfo.tsx
@@ -18,7 +18,7 @@ import SetUpInfoModal from './SetUpInfoModal';
 const UserInfo = ({ mypage }: { mypage?: boolean }) => {
   const user = useAppSelector((state) => state.user.user);
   const { cat, rocket } = getCatInfoByQuery(user?.profileImg);
-  const nickname = sessionStorage.getItem('nickname');
+  const token = sessionStorage.getItem('accessToken');
 
   const [loginModalVisible, setLoginModalVisible] = useState<boolean>(false);
   const [createGameModalVisible, setCreateGameModalVisible] = useState<boolean>(false);
@@ -42,12 +42,12 @@ const UserInfo = ({ mypage }: { mypage?: boolean }) => {
           <Cat type="body" catTheme={cat} rocketTheme={rocket} scale={2} />
         )}
         <UserStatusBox>
-          {!nickname ? (
+          {!token ? (
             <span className="user-status-box-login" onClick={() => setLoginModalVisible(true)}>
               로그인이 필요합니다
             </span>
           ) : (
-            <span>{user?.nickname === nickname ? user.nickname : nickname}</span>
+            <span>{user?.nickname}</span>
           )}
         </UserStatusBox>
       </ProfileBox>

--- a/src/redux/modules/userSlice.ts
+++ b/src/redux/modules/userSlice.ts
@@ -33,6 +33,18 @@ export const __getUserKeyword = createAsyncThunk('getUserKeyword', async (_, thu
   }
 });
 
+export const __updateUserInfo = createAsyncThunk(
+  'updateUserInfo',
+  async ({ newNickname, newProfileImg }: { newNickname: string; newProfileImg: string }, thunkAPI) => {
+    try {
+      await userApi.updateUserInfo({ newNickname, newProfileImg });
+      return thunkAPI.fulfillWithValue({ newNickname, newProfileImg });
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error);
+    }
+  },
+);
+
 const userSlice = createSlice({
   name: 'user',
   initialState,
@@ -54,6 +66,13 @@ const userSlice = createSlice({
     });
     builder.addCase(__getUserKeyword.fulfilled, (state, action) => {
       state.keywords = action.payload;
+    });
+    builder.addCase(__updateUserInfo.fulfilled, (state, action) => {
+      if (state.user) {
+        state.user.profileImg = action.payload.newProfileImg;
+        state.user.nickname = action.payload.newNickname;
+        return;
+      }
     });
   },
 });

--- a/src/redux/modules/userSlice.ts
+++ b/src/redux/modules/userSlice.ts
@@ -59,7 +59,6 @@ const userSlice = createSlice({
     builder.addCase(__getUserInfo.fulfilled, (state, action) => {
       state.isLogined = true;
       state.user = action.payload;
-      sessionStorage.setItem('nickname', action.payload.nickname);
     });
     builder.addCase(__getUserInfo.rejected, (state) => {
       state.isLogined = false;


### PR DESCRIPTION
### Issue

- resolves #133

<br>

### 작업 내용

- 회원정보 수정 기능 추가
- 닉네임 중복 검사 api 수정
- 첫 로그인시 띄우는 정보 수정 모달일 경우 생성하기 클릭 시 웰컴 모달 띄우도록 설정
- 메인 페이지 깜빡임 현상으로 스토리지에 닉네임 저장했던 부분 삭제

<br>

### 리뷰어에게 할 말

UI에 정보가 들어가는 부분이 많아져서 스토리지에 닉네임 저장했던거 그냥 삭제했습니당,,
깜빡이는 부분이 고양이밖에 없는 것 같아서,, 괜찮지 않을까용?,, 움짤 뒷부분에 새로고침 화면도 있숩니다

![새로고침](https://user-images.githubusercontent.com/118031423/216273477-8469201e-1233-43f2-ada5-1ae621f8df13.gif)
