### PR TITLE
FIX: 게임방 상태 변화에 따른 미디어스트림 on/off 동작 문제

### DIFF
--- a/src/components/game/Cam.tsx
+++ b/src/components/game/Cam.tsx
@@ -48,7 +48,7 @@ const Cam = ({ userId, userStream, nickname, profileImg, video, audio, isMe, isH
     <CamLayout size={size}>
       <VideoBox>
         <CamStatus userId={userId} isHost={isHost} />
-        {userStream && video ? (
+        {userStream ? (
           <Video ref={videoRef} autoPlay playsInline muted={isMe} size={size} />
         ) : (
           <EmptyVideo size={size}>

--- a/src/components/game/CamList.tsx
+++ b/src/components/game/CamList.tsx
@@ -6,15 +6,14 @@ import Slider from 'react-slick';
 import styled from 'styled-components';
 
 import useStreamUpdateSocket from '@hooks/socket/useStreamUpdateSocket';
-import { useAppDispatch, useAppSelector } from '@redux/hooks';
-import { setUserCam, setUserMic } from '@redux/modules/userMediaSlice';
+import { useAppSelector } from '@redux/hooks';
 
 import Cam from './Cam';
 import CamListSliderArrow from './CamListSliderArrow';
 
 // TODO: 사용자들의 캠 대신 이름으로 참여 여부를 먼저 나타냈다. 수정되어야 한다.
 const CamList = () => {
-  const { userStream, userMic, userCam, userStreamRef } = useAppSelector((state) => state.userMedia);
+  const { userStream, userMic, userCam } = useAppSelector((state) => state.userMedia);
   const { playerList, playerStreamMap } = useAppSelector((state) => state.playerMedia);
   const [hasSlider, setHasSlider] = useState<{ hasPrev: boolean; hasNext: boolean }>({
     hasPrev: false,
@@ -22,18 +21,7 @@ const CamList = () => {
   });
   const { user } = useAppSelector((state) => state.user);
   const { turn } = useAppSelector((state) => state.gamePlay);
-  const dispatch = useAppDispatch();
   const { onUpdateUserStream, offUpdateUserStream } = useStreamUpdateSocket();
-
-  useEffect(() => {
-    // XXX: 우선은 끈 상태로 시작하게 했지만..???
-    if (userStreamRef?.current) {
-      dispatch(setUserCam(false));
-      dispatch(setUserMic(false));
-      userStreamRef.current.getAudioTracks().forEach((track) => (track.enabled = !track.enabled));
-      userStreamRef.current.getVideoTracks().forEach((track) => (track.enabled = !track.enabled));
-    }
-  }, []);
 
   useEffect(() => {
     onUpdateUserStream();

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -54,7 +54,7 @@ const useGameUpdateSocket = () => {
         }
         const { nickname, socketId, userId } = data.eventUserInfo;
         dispatch(updateRoom(data.room));
-        if (data.event === 'enter' || data.event === 'leave') {
+        if (isInOutEvent(data.event)) {
           dispatch(
             setPlayerList(
               data.room.participants.map((participant) => {

--- a/src/hooks/socket/useGameUpdateSocket.ts
+++ b/src/hooks/socket/useGameUpdateSocket.ts
@@ -3,7 +3,7 @@ import useWebRTC from '@hooks/useWebRTC';
 import { useAppDispatch } from '@redux/hooks';
 import { clearAllGamePlayState, setPlayState } from '@redux/modules/gamePlaySlice';
 import { addChat, updateRoom } from '@redux/modules/gameRoomSlice';
-import { setPlayerList } from '@redux/modules/playerMediaSlice';
+import { removePlayerStreamById, setPlayerList } from '@redux/modules/playerMediaSlice';
 
 import { GameRoomDetail } from '@customTypes/gameRoomType';
 import { EventUserInfo } from '@customTypes/socketType';
@@ -22,7 +22,7 @@ const useGameUpdateSocket = () => {
   const { on, off } = socketInstance;
 
   function isInOutEvent(event: string) {
-    return event === 'enter' || event === 'leave' || event === 'leave-force';
+    return event === 'enter' || event === 'leave';
   }
 
   const onAnnounceRoomUpdate = () => {
@@ -34,7 +34,7 @@ const useGameUpdateSocket = () => {
         data: {
           room: GameRoomDetail;
           eventUserInfo: EventUserInfo;
-          event: 'enter' | 'leave' | 'leave-force' | 'ready' | 'start' | 'game-end';
+          event: 'enter' | 'leave' | 'ready' | 'start' | 'game-end';
         };
       }) => {
         if (data.event === 'game-end') {
@@ -54,7 +54,18 @@ const useGameUpdateSocket = () => {
         }
         const { nickname, socketId, userId } = data.eventUserInfo;
         dispatch(updateRoom(data.room));
-        dispatch(setPlayerList(data.room.participants));
+        if (data.event === 'enter' || data.event === 'leave') {
+          dispatch(
+            setPlayerList(
+              data.room.participants.map((participant) => {
+                return { ...participant, audio: participant.audio ?? true, video: participant.video ?? true };
+              }),
+            ),
+          );
+        }
+        if (data.event === 'leave') {
+          dispatch(removePlayerStreamById(socketId));
+        }
         if (isInOutEvent(data.event)) {
           const InOutEventMessageType: InOutEventMessageType = {
             enter: `'${nickname}'님이 입장하셨습니다.`,
@@ -66,7 +77,7 @@ const useGameUpdateSocket = () => {
               nickname: '알림',
               userId,
               socketId,
-              message: InOutEventMessageType[data.event as 'enter' | 'leave' | 'leave-force'],
+              message: InOutEventMessageType[data.event as 'enter' | 'leave'],
               type: 'notification',
             }),
           );

--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -164,7 +164,7 @@ const useWebRTC = () => {
 
   useEffect(() => {
     return () => {
-      emit('webrtc- leave');
+      emit(PUBLISH.webRTCLeave);
       Object.entries(playerStreamMap).forEach((map) => {
         const socketId = map[0];
         const stream = map[1];

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -15,6 +15,8 @@ import usePopState from '@hooks/usePopState';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
 import { clearAllGamePlayState } from '@redux/modules/gamePlaySlice';
 import { addChat, clearScore, updateRoom } from '@redux/modules/gameRoomSlice';
+import { clearPlayerStream } from '@redux/modules/playerMediaSlice';
+import { clearMedia } from '@redux/modules/userMediaSlice';
 import { alertToast } from '@utils/toast';
 
 import CamList from '@components/game/CamList';
@@ -58,8 +60,10 @@ const Room = () => {
       offError();
       userStreamRef && destroyLocalStream(userStreamRef);
       dispatch(updateRoom(null));
+      dispatch(clearPlayerStream());
       dispatch(clearAllGamePlayState());
       dispatch(clearScore());
+      dispatch(clearMedia());
     };
   }, []);
 

--- a/src/redux/modules/playerMediaSlice.ts
+++ b/src/redux/modules/playerMediaSlice.ts
@@ -46,9 +46,19 @@ const playerMediaSlice = createSlice({
     setPlayerList: (state, action: PayloadAction<WebRTCUser[]>) => {
       state.playerList = action.payload;
     },
+    removePlayerStreamById: (state, action: PayloadAction<string>) => {
+      delete state.playerPeerMap[action.payload];
+      delete state.playerStreamMap[action.payload];
+    },
+    clearPlayerStream: (state) => {
+      state.playerPeerMap = {};
+      state.playerStreamMap = {};
+      state.playerList = [];
+    },
   },
 });
 
-export const { addPlayerStream, addPlayerPeer, setPlayerList } = playerMediaSlice.actions;
+export const { addPlayerStream, addPlayerPeer, setPlayerList, removePlayerStreamById, clearPlayerStream } =
+  playerMediaSlice.actions;
 
 export default playerMediaSlice;

--- a/src/redux/modules/userMediaSlice.ts
+++ b/src/redux/modules/userMediaSlice.ts
@@ -60,6 +60,18 @@ const userMediaSlice = createSlice({
       state.isMediaLoading = false;
       state.isMediaSuccess = false;
     },
+    clearMedia: (state) => {
+      state.userCam = false;
+      state.userMic = false;
+      state.localDevice = {
+        video: false,
+        audio: false,
+      };
+      state.isMediaLoading = false;
+      state.isMediaSuccess = false;
+      state.userStreamRef = undefined;
+      state.userStream = new MediaStream();
+    },
   },
 });
 
@@ -73,6 +85,7 @@ export const {
   setMediaLoading,
   setMediaDone,
   initMediaStatus,
+  clearMedia,
 } = userMediaSlice.actions;
 
 export default userMediaSlice;


### PR DESCRIPTION
### Issue

- resolves #164 
<br>

### 요약

게임방 상태 변화에 따른 미디어스트림 on/off 동작 문제 해결

<br>

### 작업 내용

- [x] 레디 / 캔슬 누르면 미디어 스트리밍 다 꺼짐
- [x] 내가 레디 / 캔슬 누르면 다른 사람들 미디어가 안보이고 안 들림
- [x] 새로운 사람이 방에 입장하거나 나가면 미디어스트림이 꺼지며 각자 다시 켜야하는 문제를 해결
- [x] 마이크/캠이 독립적으로 on/off 했을 때 동작하는지 확인한다.


<br>


 
