### PR TITLE
FEAT: 방 입장 시 기존 유저들의 캠 상태 반영 #171

### DIFF
--- a/src/components/game/Cam.tsx
+++ b/src/components/game/Cam.tsx
@@ -49,7 +49,20 @@ const Cam = ({ userId, userStream, nickname, profileImg, video, audio, isMe, isH
       <VideoBox>
         <CamStatus userId={userId} isHost={isHost} />
         {userStream ? (
-          <Video ref={videoRef} autoPlay playsInline muted={isMe} size={size} />
+          <>
+            <Video ref={videoRef} autoPlay playsInline muted={isMe} size={size} />
+            {!video && (
+              <EmptyVideo size={size}>
+                <Cat
+                  catTheme={cat}
+                  rocketTheme={rocket}
+                  type="face"
+                  hasIdlePopupAnimation={false}
+                  scale={size === 'sub' ? 0.8 : 2}
+                />
+              </EmptyVideo>
+            )}
+          </>
         ) : (
           <EmptyVideo size={size}>
             <Cat

--- a/src/components/game/CamList.tsx
+++ b/src/components/game/CamList.tsx
@@ -11,7 +11,6 @@ import { useAppSelector } from '@redux/hooks';
 import Cam from './Cam';
 import CamListSliderArrow from './CamListSliderArrow';
 
-// TODO: 사용자들의 캠 대신 이름으로 참여 여부를 먼저 나타냈다. 수정되어야 한다.
 const CamList = () => {
   const { userStream, userMic, userCam } = useAppSelector((state) => state.userMedia);
   const { playerList, playerStreamMap } = useAppSelector((state) => state.playerMedia);
@@ -21,7 +20,11 @@ const CamList = () => {
   });
   const { user } = useAppSelector((state) => state.user);
   const { turn } = useAppSelector((state) => state.gamePlay);
-  const { onUpdateUserStream, offUpdateUserStream } = useStreamUpdateSocket();
+  const { onUpdateUserStream, offUpdateUserStream, emitUpdateUserStream } = useStreamUpdateSocket();
+
+  useEffect(() => {
+    emitUpdateUserStream({ audio: userMic, video: userCam });
+  }, [playerStreamMap.length]);
 
   useEffect(() => {
     onUpdateUserStream();


### PR DESCRIPTION
### Issue

- resolves #171

<br>


### 작업 내용

- 방에 입장했을 때 기존유저의 현재 캠/마이크 상태를 받아올 수 있게 한다.

- 캠이 꺼졌을 때 고양이 커버를 추가한다

<br>

 
