### PR TITLE
FIX: keydown 시 한글 조합중인지 검사 추가

### DIFF
--- a/src/components/game/ChatLog.tsx
+++ b/src/components/game/ChatLog.tsx
@@ -64,7 +64,7 @@ const ChatLog = () => {
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!chat || e.key !== 'Enter') {
+    if (!chat || e.key !== 'Enter' || e.nativeEvent.isComposing) {
       return;
     }
     if (checkEvaluatable() && /^[0-5]$/g.test(chat) && !isTurnEvaluated) {


### PR DESCRIPTION


### 작업 내용

- 맥에서 한글 채팅을 마지막으로 입력 시 두번 채팅이 보내지는 문제 해결해보기 

- 직접 테스트해볼 수 없기 때문에 원인이나 방법을 계속 찾아 볼 것 
