### PR TITLE
FEAT: 동적 긴급 알림 띄우기

### DIFF
--- a/src/components/home/SpecialNotificationModal.tsx
+++ b/src/components/home/SpecialNotificationModal.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+import Modal from '@components/common/Modal';
+
+interface SpecialNotificationModalProps {
+  visible: boolean;
+  onClose: () => void;
+  contents: string;
+}
+
+const SpecialNotificationModal = ({ visible, onClose, contents }: SpecialNotificationModalProps) => {
+  return (
+    <Modal visible={visible} onClose={onClose}>
+      <SpecialNotificationModalLayout>
+        <h1>특 별 공 지</h1>
+        <p>{contents}</p>
+      </SpecialNotificationModalLayout>
+    </Modal>
+  );
+};
+
+const SpecialNotificationModalLayout = styled.div`
+  padding: 40px 40px;
+  gap: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: ${(props) => props.theme.colors.white1};
+`;
+
+export default SpecialNotificationModal;

--- a/src/hooks/useSpecialNotification.tsx
+++ b/src/hooks/useSpecialNotification.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+interface NotificationType {
+  hasAlert: string;
+  contents: string;
+}
+
+const useSpecialNotification = () => {
+  const lambdaNotificationURL = process.env.REACT_APP_LAMBDA_NOTI;
+  const [hasNotification, setHasNotification] = useState<boolean>(false);
+  const [contents, setContents] = useState<string>('');
+
+  useEffect(() => {
+    console.log(lambdaNotificationURL);
+    if (!lambdaNotificationURL) {
+      return;
+    }
+    (async () => {
+      const notificationResult = await axios.get('https://au12xtunpb.execute-api.ap-northeast-2.amazonaws.com/prod');
+      const data = notificationResult.data.body as NotificationType;
+      if (data.hasAlert === 'true') {
+        setHasNotification(true);
+        setContents(data.contents);
+      }
+    })();
+  }, []);
+
+  function closeNotification() {
+    setHasNotification(false);
+  }
+
+  return { hasNotification, contents, closeNotification };
+};
+
+export default useSpecialNotification;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react';
 
 import useErrorSocket from '@hooks/socket/useErrorSocket';
 import useDuplicatedUserInvalidate from '@hooks/useDuplicatedUserInvalidate';
+import useSpecialNotification from '@hooks/useSpecialNotification';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
 import { logout } from '@redux/modules/userSlice';
 
 import AnnouncementModal from '@components/home/AnnouncementModal';
 import RoomList from '@components/home/RoomList';
 import SetUpInfoModal from '@components/home/SetUpInfoModal';
+import SpecialNotificationModal from '@components/home/SpecialNotificationModal';
 import UserInfo from '@components/home/UserInfo';
 import ContentContainer from '@components/layout/ContentContainer';
 import MainTemplate from '@components/layout/MainTemplate';
@@ -17,7 +19,7 @@ const Main = () => {
   const dispatch = useAppDispatch();
   const { onError, offError } = useErrorSocket();
   const { invalidate } = useDuplicatedUserInvalidate();
-
+  const { contents, hasNotification, closeNotification } = useSpecialNotification();
   useEffect(() => {
     onError([
       { target: 'status', value: 401, callback: () => dispatch(logout()) },
@@ -56,6 +58,9 @@ const Main = () => {
     <MainTemplate>
       <ContentContainer title="PROFILE">
         <UserInfo />
+        {hasNotification && (
+          <SpecialNotificationModal visible={hasNotification} onClose={closeNotification} contents={contents} />
+        )}
         {setUpInfoModalVisible && (
           <SetUpInfoModal visible={setUpInfoModalVisible} onClose={() => setSetUpInfoModalVisible(false)} />
         )}


### PR DESCRIPTION
### Issue

- resolves #205 

<br>

### 요약

동적 긴급 알림을 띄울 수 있게 한다.

<br>

### 작업 내용

- 서버리스 api를 구성
- 메인 페이지에서 긴급공지를 띄워야한다면 내용과 함께 추가

<br>

 
