### PR TITLE
FEAT: 발표종료 후 토론시간에 하는 평가 시스템 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "json-server": "^0.17.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-draggable": "^4.4.5",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.6.1",
         "react-scripts": "5.0.1",
@@ -27380,6 +27381,19 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-element-to-jsx-string": {
@@ -54796,6 +54810,15 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-draggable": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+      "requires": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
       }
     },
     "react-element-to-jsx-string": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "json-server": "^0.17.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-draggable": "^4.4.5",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.6.1",
     "react-scripts": "5.0.1",

--- a/src/components/common/CircularProgress.tsx
+++ b/src/components/common/CircularProgress.tsx
@@ -1,0 +1,86 @@
+import styled, { keyframes } from 'styled-components';
+
+const CircularProgress = ({ second }: { second: number }) => {
+  return (
+    <CircularProgressLayout>
+      <ProgressBox second={second}>
+        <OverlayBox />
+        <div className="left"></div>
+        <div className="right"></div>
+      </ProgressBox>
+    </CircularProgressLayout>
+  );
+};
+
+const LoadRightHalf = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(180deg);
+  }
+`;
+
+const LoadLeftHalf = keyframes`
+  0% {
+    z-index: 100;
+    transform: rotate(180deg);
+  }
+  100% {
+    z-index: 100;
+    transform: rotate(360deg);
+  }
+`;
+
+const CircularProgressLayout = styled.div`
+  position: relative;
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+`;
+
+const ProgressBox = styled.div<{ second: number }>`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  overflow: hidden;
+  position: relative;
+  background: #07070c;
+  text-align: center;
+  line-height: 50px;
+  margin: 20px;
+
+  .left,
+  .right {
+    width: 50%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: 10px solid ${(props) => props.theme.colors.lightGrey2};
+    border-radius: 100px 0px 0px 100px;
+    border-right: 0;
+    transform-origin: right;
+  }
+
+  .left {
+    animation: ${LoadRightHalf} ${(props) => props.second / 2}s linear forwards;
+  }
+
+  :first-of-type .right,
+  :last-of-type .right {
+    animation: ${LoadLeftHalf} ${(props) => props.second / 2}s linear forwards ${(props) => props.second / 2}s;
+  }
+`;
+
+const OverlayBox = styled.div`
+  width: 50%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  background-color: #07070c;
+`;
+
+export default CircularProgress;

--- a/src/components/common/CircularProgress.tsx
+++ b/src/components/common/CircularProgress.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import styled, { keyframes } from 'styled-components';
 
 const CircularProgress = ({ second }: { second: number }) => {
@@ -83,4 +85,4 @@ const OverlayBox = styled.div`
   background-color: #07070c;
 `;
 
-export default CircularProgress;
+export default React.memo(CircularProgress);

--- a/src/components/game/ChatLog.tsx
+++ b/src/components/game/ChatLog.tsx
@@ -4,12 +4,8 @@ import styled from 'styled-components';
 
 import useChatSocket from '@hooks/socket/useChatSocket';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
-import { setEvaluated } from '@redux/modules/gamePlaySlice';
-import { addChat, clearChatList } from '@redux/modules/gameRoomSlice';
-import { useGetUserInfoQuery } from '@redux/query/user';
-import { alertToast } from '@utils/toast';
+import { clearChatList } from '@redux/modules/gameRoomSlice';
 
-// TODO: 색상 변경할 것
 interface ChatColorType {
   notification: string;
   answer: string;
@@ -26,34 +22,9 @@ const ChatColor: ChatColorType = {
 
 const ChatLog = () => {
   const { chatList } = useAppSelector((state) => state.gameRoom);
-  const { playState, turn, isTurnEvaluated } = useAppSelector((state) => state.gamePlay);
-  const { data } = useGetUserInfoQuery();
-  const user = data;
   const [chat, setChat] = useState<string>('');
   const dispatch = useAppDispatch();
-  const { emitSendChat, emitTurnEvaluation } = useChatSocket();
-
-  useEffect(() => {
-    dispatch(setEvaluated(false));
-  }, [turn]);
-
-  useEffect(() => {
-    if (checkEvaluatable()) {
-      dispatch(
-        addChat({
-          nickname: '',
-          message: '[0~5] 사이의 평점을 입력해 발표자를 평가 해주세요!',
-          type: 'notification',
-          socketId: '',
-          userId: 0,
-        }),
-      );
-      alertToast(`정답은 "${turn?.keyword}" 입니다.`, 'success', {
-        hideProgressBar: true,
-        autoClose: 5000,
-      });
-    }
-  }, [playState]);
+  const { emitSendChat } = useChatSocket();
 
   useEffect(() => {
     return () => {
@@ -61,26 +32,7 @@ const ChatLog = () => {
     };
   }, []);
 
-  const checkEvaluatable = () => {
-    return playState?.event === 'discussionTimer' && user?.userId !== turn?.speechPlayer;
-  };
-
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'Enter' && checkEvaluatable() && /^[0-5]$/g.test(chat) && !isTurnEvaluated) {
-      emitTurnEvaluation(Number(chat), turn?.currentTurn ?? 0);
-      dispatch(setEvaluated(true));
-      dispatch(
-        addChat({
-          nickname: '',
-          message: '평가가 반영되었습니다!',
-          type: 'notification',
-          socketId: '',
-          userId: 0,
-        }),
-      );
-      setChat('');
-      return;
-    }
     if (!chat || e.key !== 'Enter' || e.nativeEvent.isComposing) {
       return;
     }

--- a/src/components/game/PresentEvaluate.tsx
+++ b/src/components/game/PresentEvaluate.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { useAppDispatch } from '@redux/hooks';
+import { setEvaluated } from '@redux/modules/gamePlaySlice';
+
+import Button from '@components/common/Button';
+import CircularProgress from '@components/common/CircularProgress';
+import GameButtonContainer from '@components/layout/GameButtonContainer';
+
+import RatingCats from './RatingCats';
+
+export interface PresentEvaluateProps {
+  currentTurn: number;
+  emitEvaluate: (score: number, turn: number) => void;
+}
+
+const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) => {
+  const [inputScore, setInputScore] = useState<number>(1);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      dispatch(setEvaluated(true));
+    }, 7000);
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
+  const handleSetScoreChange = (value: number) => {
+    setInputScore(value);
+  };
+
+  const handleEvaluateButtonClick = () => {
+    emitEvaluate(inputScore, currentTurn);
+    dispatch(setEvaluated(true));
+  };
+
+  return (
+    <GameButtonContainer>
+      <CircularProgressBox>
+        <CircularProgress second={7} />
+      </CircularProgressBox>
+      <PresentEvaluateLayout>
+        <DescriptionContainer>
+          <DescriptionText>발표를 평가해주세요!!</DescriptionText>
+          <SubDescriptionText>미제출 시 최고점으로 자동 평가됩니다!</SubDescriptionText>
+        </DescriptionContainer>
+        <RatingCats setInputScore={handleSetScoreChange} />
+        <ButtonContainer>
+          <SubmitButton onClick={handleEvaluateButtonClick}>평가하기</SubmitButton>
+          <LeaveButton onClick={() => dispatch(setEvaluated(true))}>취소하기</LeaveButton>
+        </ButtonContainer>
+      </PresentEvaluateLayout>
+    </GameButtonContainer>
+  );
+};
+
+const PresentEvaluateLayout = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  grid-row-gap: 30px;
+`;
+
+const CircularProgressBox = styled.div`
+  position: absolute;
+  transform: scale(0.7);
+  right: 0;
+  top: 0;
+`;
+
+const DescriptionContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  grid-row-gap: 12px;
+`;
+
+const DescriptionText = styled.p`
+  font-size: 24px;
+  color: ${(props) => props.theme.colors.ivory1};
+`;
+
+const SubDescriptionText = styled.p`
+  font-size: 14px;
+  color: ${(props) => props.theme.colors.lightGrey10};
+`;
+
+const ButtonContainer = styled.div`
+  margin-top: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  grid-column-gap: 30px;
+`;
+
+const LeaveButton = styled(Button)`
+  font-size: 18px;
+  width: 120px;
+  height: 48px;
+`;
+
+const SubmitButton = styled(Button)`
+  font-size: 18px;
+  background-color: ${(props) => props.theme.colors.purple1};
+  width: 120px;
+  height: 48px;
+`;
+
+export default PresentEvaluate;

--- a/src/components/game/PresentEvaluate.tsx
+++ b/src/components/game/PresentEvaluate.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 
+import Draggable from 'react-draggable';
 import styled from 'styled-components';
 
+import useDraggable from '@hooks/useDraggable';
 import { useAppDispatch } from '@redux/hooks';
 import { setEvaluated } from '@redux/modules/gamePlaySlice';
 
@@ -19,6 +21,7 @@ export interface PresentEvaluateProps {
 const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) => {
   const [inputScore, setInputScore] = useState<number>(1);
   const dispatch = useAppDispatch();
+  const { isDragging, trackPosition, handleDragStart, handleDragEnd } = useDraggable();
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
@@ -39,26 +42,36 @@ const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) =>
   };
 
   return (
-    <GameButtonContainer>
-      <CircularProgressBox>
-        <CircularProgress second={7} />
-      </CircularProgressBox>
-      <PresentEvaluateLayout>
-        <DescriptionContainer>
-          <DescriptionText>발표를 평가해주세요!!</DescriptionText>
-          <SubDescriptionText>미제출 시 최고점으로 자동 평가됩니다!</SubDescriptionText>
-        </DescriptionContainer>
-        <RatingCats setInputScore={handleSetScoreChange} />
-        <ButtonContainer>
-          <SubmitButton onClick={handleEvaluateButtonClick}>평가하기</SubmitButton>
-          <LeaveButton onClick={() => dispatch(setEvaluated(true))}>취소하기</LeaveButton>
-        </ButtonContainer>
-      </PresentEvaluateLayout>
-    </GameButtonContainer>
+    <Draggable onDrag={(e, data) => trackPosition(data)} onStart={handleDragStart} onStop={handleDragEnd}>
+      <DraggableBox isDragging={isDragging}>
+        <GameButtonContainer>
+          <CircularProgressBox>
+            <CircularProgress second={7} />
+          </CircularProgressBox>
+          <PresentEvaluateBox>
+            <DescriptionContainer>
+              <DescriptionText>발표를 평가해주세요!!</DescriptionText>
+              <SubDescriptionText>미제출 시 최고점으로 자동 평가됩니다!</SubDescriptionText>
+            </DescriptionContainer>
+
+            <RatingCats setInputScore={handleSetScoreChange} />
+            <ButtonContainer>
+              <SubmitButton onClick={handleEvaluateButtonClick}>평가하기</SubmitButton>
+              <LeaveButton onClick={() => dispatch(setEvaluated(true))}>취소하기</LeaveButton>
+            </ButtonContainer>
+          </PresentEvaluateBox>
+        </GameButtonContainer>
+      </DraggableBox>
+    </Draggable>
   );
 };
 
-const PresentEvaluateLayout = styled.div`
+const DraggableBox = styled.div<{ isDragging: boolean }>`
+  opacity: ${(props) => (props.isDragging ? 0.7 : 1)};
+  cursor: move;
+`;
+
+const PresentEvaluateBox = styled.div`
   position: relative;
   display: flex;
   justify-content: center;

--- a/src/components/game/PresentEvaluate.tsx
+++ b/src/components/game/PresentEvaluate.tsx
@@ -18,6 +18,8 @@ export interface PresentEvaluateProps {
   emitEvaluate: (score: number, turn: number) => void;
 }
 
+const SCORING_TIME = 15;
+
 const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) => {
   const [inputScore, setInputScore] = useState<number>(1);
   const dispatch = useAppDispatch();
@@ -26,7 +28,7 @@ const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) =>
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       dispatch(setEvaluated(true));
-    }, 7000);
+    }, SCORING_TIME * 1000);
     return () => {
       clearTimeout(timeoutId);
     };
@@ -42,13 +44,18 @@ const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) =>
   };
 
   return (
-    <Draggable onDrag={(e, data) => trackPosition(data)} onStart={handleDragStart} onStop={handleDragEnd}>
+    <Draggable
+      onDrag={(_, data) => trackPosition(data)}
+      onStart={handleDragStart}
+      onStop={handleDragEnd}
+      cancel=".not-draggable"
+    >
       <DraggableBox isDragging={isDragging}>
         <GameButtonContainer>
           <CircularProgressBox>
-            <CircularProgress second={7} />
+            <CircularProgress second={SCORING_TIME} />
           </CircularProgressBox>
-          <PresentEvaluateBox>
+          <PresentEvaluateBox className="not-draggable">
             <DescriptionContainer>
               <DescriptionText>발표를 평가해주세요!!</DescriptionText>
               <SubDescriptionText>미제출 시 최고점으로 자동 평가됩니다!</SubDescriptionText>
@@ -72,6 +79,7 @@ const DraggableBox = styled.div<{ isDragging: boolean }>`
 `;
 
 const PresentEvaluateBox = styled.div`
+  cursor: default;
   position: relative;
   display: flex;
   justify-content: center;

--- a/src/components/game/PresentEvaluate.tsx
+++ b/src/components/game/PresentEvaluate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import Draggable from 'react-draggable';
 import styled from 'styled-components';
@@ -34,9 +34,9 @@ const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) =>
     };
   }, []);
 
-  const handleSetScoreChange = (value: number) => {
+  const handleSetScoreChange = useCallback((value: number) => {
     setInputScore(value);
-  };
+  }, []);
 
   const handleEvaluateButtonClick = () => {
     emitEvaluate(inputScore, currentTurn);
@@ -60,7 +60,6 @@ const PresentEvaluate = ({ currentTurn, emitEvaluate }: PresentEvaluateProps) =>
               <DescriptionText>발표를 평가해주세요!!</DescriptionText>
               <SubDescriptionText>미제출 시 최고점으로 자동 평가됩니다!</SubDescriptionText>
             </DescriptionContainer>
-
             <RatingCats setInputScore={handleSetScoreChange} />
             <ButtonContainer>
               <SubmitButton onClick={handleEvaluateButtonClick}>평가하기</SubmitButton>

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -37,6 +37,11 @@ const Presenter = () => {
     if (playState?.event === 'gameEnd') {
       setResultModalVisible(true);
     }
+    if (playState?.event === 'startCount') {
+      alertToast('게임시작!', 'info', {
+        hideProgressBar: true,
+      });
+    }
     if (isEvaluatable()) {
       alertToast(`정답은 "${turn?.keyword}" 입니다.`, 'success', {
         hideProgressBar: true,

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -26,8 +26,7 @@ const Presenter = () => {
   const { emitGameReady, emitGameStart } = useGameInitiationSocket();
   const { emitTurnEvaluation } = useChatSocket();
   const currentUser = room?.participants.find((participant) => participant.userId === user?.userId);
-  const presenterNickname =
-    room?.participants.find((participant) => participant.userId === turn?.speechPlayer)?.nickname ?? '';
+  const presenter = room?.participants.find((participant) => participant.userId === turn?.speechPlayer);
   const isMe = user?.userId === turn?.speechPlayer;
 
   const isEvaluatable = () => {
@@ -55,7 +54,7 @@ const Presenter = () => {
       <PresentationInfo
         isMe={isMe}
         keyword={turn?.keyword as string}
-        nickname={presenterNickname}
+        nickname={presenter?.nickname ?? ''}
         event={playState?.event}
       />
       {playState?.event === 'speechTimer' && turn && (
@@ -63,10 +62,10 @@ const Presenter = () => {
       )}
       {room?.isGameOn && turn && (
         <PresenterCam
-          nickname={presenterNickname}
+          nickname={presenter?.nickname ?? ''}
           isMe={isMe}
           userId={turn.speechPlayer}
-          profileImg={currentUser?.profileImg}
+          profileImg={presenter?.profileImg}
         />
       )}
       {!room?.isGameOn && (

--- a/src/components/game/RatingCats.tsx
+++ b/src/components/game/RatingCats.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+
+import styled, { keyframes } from 'styled-components';
+
+import cursorIcon from '@assets/svg_cursorIcon.svg';
+
+import CatIcon from '@components/character/CatIcon';
+
+export interface RatingCatsProps {
+  setInputScore: (value: number) => void;
+}
+
+const RatingCats = ({ setInputScore }: RatingCatsProps) => {
+  const [selectedList, setSelectedList] = useState<boolean[]>([true]);
+
+  const handleRatingCatClick = (index: number) => {
+    setInputScore(index + 1);
+    setSelectedList([...Array(5)].map((_, idx) => index >= idx));
+  };
+
+  return (
+    <RatingCatsLayout>
+      {[...Array(5)].map((_, index) => (
+        <RatingCatBox key={index} selected={selectedList[index]}>
+          <div onClick={() => handleRatingCatClick(index)}></div>
+          <CatIcon catTheme="white" />
+        </RatingCatBox>
+      ))}
+    </RatingCatsLayout>
+  );
+};
+
+const RatingCatsLayout = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 36px;
+`;
+
+const RatingCatRotateAnimation = keyframes`
+    0% {
+        transform: rotate(-1deg);
+    }
+    50% {
+        transform: rotate(1deg);
+    }
+    100% {
+        transform: rotate(-1deg);
+    }
+`;
+
+const RatingCatBox = styled.div<{ selected: boolean }>`
+  position: relative;
+  transform: scale(2.1);
+  margin-right: 36px;
+  opacity: ${(props) => (props.selected ? 1 : 0.3)};
+  & > div:first-child {
+    position: absolute;
+    cursor: url(${cursorIcon}), pointer;
+    left: 2px;
+    top: 2px;
+    width: 26px;
+    height: 21px;
+    z-index: 2;
+  }
+  & > div:nth-child(2) {
+    animation: ${RatingCatRotateAnimation} ${(props) => (props.selected ? 0.3 : 0)}s infinite;
+    -webkit-animation: ${RatingCatRotateAnimation} ${(props) => (props.selected ? 0.3 : 0)}s infinite;
+    -moz-animation: ${RatingCatRotateAnimation} ${(props) => (props.selected ? 0.3 : 0)}s infinite;
+  }
+`;
+
+export default RatingCats;

--- a/src/components/game/RatingCats.tsx
+++ b/src/components/game/RatingCats.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 import styled, { keyframes } from 'styled-components';
 
@@ -70,4 +70,4 @@ const RatingCatBox = styled.div<{ selected: boolean }>`
   }
 `;
 
-export default RatingCats;
+export default React.memo(RatingCats);

--- a/src/components/layout/GameButtonContainer.tsx
+++ b/src/components/layout/GameButtonContainer.tsx
@@ -35,6 +35,7 @@ const GameButtonContainerHeaderBox = styled.div`
 `;
 
 const GameButtonContainerContentBox = styled.div`
+  position: relative;
   height: 100%;
   display: flex;
   justify-content: center;

--- a/src/hooks/socket/useGameInitiationSocket.ts
+++ b/src/hooks/socket/useGameInitiationSocket.ts
@@ -1,5 +1,4 @@
 import { PUBLISH } from '@constants/socket';
-import { alertToast } from '@utils/toast';
 
 import socketInstance from './socketInstance';
 
@@ -11,9 +10,6 @@ const useGameInitiationSocket = () => {
   };
 
   const emitGameStart = () => {
-    alertToast('게임시작!', 'info', {
-      hideProgressBar: true,
-    });
     emit(PUBLISH.startGame);
   };
 

--- a/src/hooks/useDraggable.ts
+++ b/src/hooks/useDraggable.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+import { DraggableData } from 'react-draggable';
+
+const useDraggable = () => {
+  const [isDragging, setIsdragging] = useState<boolean>(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  const trackPosition = (data: DraggableData) => {
+    setPosition({ x: data.x, y: data.y });
+  };
+  const handleDragStart = () => {
+    setIsdragging(true);
+  };
+  const handleDragEnd = () => {
+    setIsdragging(false);
+  };
+
+  return { isDragging, position, trackPosition, handleDragStart, handleDragEnd };
+};
+
+export default useDraggable;

--- a/src/stories/common/CircularProgress.stories.tsx
+++ b/src/stories/common/CircularProgress.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import CircularProgress from '@components/common/CircularProgress';
+
+export default {
+  title: 'common/CircularProgress',
+  component: CircularProgress,
+} as ComponentMeta<typeof CircularProgress>;
+
+const Template: ComponentStory<typeof CircularProgress> = (args: { second: number }) => {
+  return <CircularProgress {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  second: 7,
+};

--- a/src/stories/game/PresentEvaluate.stories.tsx
+++ b/src/stories/game/PresentEvaluate.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import PresentEvaluate, { PresentEvaluateProps } from '@components/game/PresentEvaluate';
+
+export default {
+  title: 'game/PresentEvaluate',
+  component: PresentEvaluate,
+  parameters: {
+    controls: {
+      exclude: ['currentTurn'],
+    },
+  },
+} as ComponentMeta<typeof PresentEvaluate>;
+
+const Template: ComponentStory<typeof PresentEvaluate> = (args: PresentEvaluateProps) => {
+  return <PresentEvaluate {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  currentTurn: 1,
+  emitEvaluate: () => alert('HI'),
+};


### PR DESCRIPTION
### Issue

- resolves #226 

<br>

### 요약

발표종료 후 토론시간에 하는 평가 시스템 UI 개선

<br>

### 작업 내용

- 채팅으로 발표자 평가하던 기능을 제거
- 토론 시간에 평가 UI가 나오게끔 추가
- 평가 기능을 평가 UI로 리팩터링
- 평가 창이 일정 시간 이후 닫히도록 추가
- 평가 UI를 드래그 가능하게 하여 선택적으로 발표자 캠을 볼 수 있게 함(`react draggable` 사용)
- 캠 껐을 때 발표자 캠에도 본인 고양이가 나오던 것 수정

<br>

![score](https://user-images.githubusercontent.com/76927397/217480217-19c79ae2-7de2-470c-be36-c85f16176518.gif)


### 향후 개선해볼만한 것

![repaint](https://user-images.githubusercontent.com/76927397/217480494-ee2fc760-08b9-4e76-bceb-8c21ddb7983e.gif)

클릭이벤트를 막거나 불필요한 리플로우 리페인트를 없앨 수 있을지 고민해보기


### 리뷰어에게 할 말

- 스토리북도 추가했습니다
- 사실 채팅창에 평가하는 건 저도 마음에 계속 안들었었기때문에 변경해봤어요 어떤가요? 

<br>



 
