### PR TITLE
FIX: 발표자 평가 시스템 개선 후 채팅이 두번 쳐지던 문제

### DIFF
--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import useChatSocket from '@hooks/socket/useChatSocket';
+import useEvaluateSocket from '@hooks/socket/useEvaluateSocket';
 import useGameInitiationSocket from '@hooks/socket/useGameInitiationSocket';
 import { useAppDispatch, useAppSelector } from '@redux/hooks';
 import { setEvaluated } from '@redux/modules/gamePlaySlice';
@@ -24,7 +25,7 @@ const Presenter = () => {
   const { turn, playState, isTurnEvaluated } = useAppSelector((state) => state.gamePlay);
   const [resultModalVisible, setResultModalVisible] = useState<boolean>(false);
   const { emitGameReady, emitGameStart } = useGameInitiationSocket();
-  const { emitTurnEvaluation } = useChatSocket();
+  const { emitTurnEvaluation } = useEvaluateSocket();
   const currentUser = room?.participants.find((participant) => participant.userId === user?.userId);
   const presenter = room?.participants.find((participant) => participant.userId === turn?.speechPlayer);
   const isMe = user?.userId === turn?.speechPlayer;

--- a/src/hooks/socket/useChatSocket.ts
+++ b/src/hooks/socket/useChatSocket.ts
@@ -37,11 +37,7 @@ const useChatSocket = () => {
     emit(PUBLISH.sendChat, { data: { message } });
   };
 
-  const emitTurnEvaluation = (score: number, turn: number) => {
-    emit(PUBLISH.sendTurnEvaluation, { data: { score, turn } });
-  };
-
-  return { emitSendChat, emitTurnEvaluation };
+  return { emitSendChat };
 };
 
 export default useChatSocket;

--- a/src/hooks/socket/useEvaluateSocket.ts
+++ b/src/hooks/socket/useEvaluateSocket.ts
@@ -1,0 +1,14 @@
+import { PUBLISH } from '@constants/socket';
+
+import socketInstance from './socketInstance';
+
+const useEvaluateSocket = () => {
+  const { emit } = socketInstance;
+  const emitTurnEvaluation = (score: number, turn: number) => {
+    emit(PUBLISH.sendTurnEvaluation, { data: { score, turn } });
+  };
+
+  return { emitTurnEvaluation };
+};
+
+export default useEvaluateSocket;


### PR DESCRIPTION

<br>

### 요약

발표자 평가 시스템 개선 후 채팅이 두번 쳐지던 문제 해결

### 문제 상황

채팅이 두번 채팅목록에 쌓인다.


### 원인

채팅 컴포넌트에서만 쓸 줄 알고 `useChatSocket` 마운트 시 `on` 이벤트를 수신하도록 설정했는데 

`evaluate`가 채팅이 아닌 형태로 변경되고 다른 컴포넌트에서 가져와 쓰다보니 `on`이벤트를 두번 수신해서 그렇다.

<br>

### 작업 내용

- `emit evaluate` 에 대한 책임을 `chat`동작에서 분리


 
