### PR TITLE
FEAT: 게임 진행 시 키워드 힌트 보여주기

### DIFF
--- a/src/components/common/BubbleContents.tsx
+++ b/src/components/common/BubbleContents.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from 'react';
+
+import styled from 'styled-components';
+
+export interface BubbleContentsProps {
+  text: string;
+  onMouseLeave: () => void;
+}
+
+const BubbleContents = ({ text, onMouseLeave }: BubbleContentsProps) => {
+  const [height, setHeight] = useState<number>(40);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (text && ref.current) {
+      setHeight(ref.current.offsetHeight);
+    }
+  }, [text]);
+  return (
+    <BubbleContentsLayout ref={ref} onMouseLeave={onMouseLeave} height={height}>
+      <div>
+        <div className="border-width" style={{ left: '0', top: '-4px' }}></div>
+        <div className="border-height" style={{ left: '-4px', top: '0px' }}></div>
+        <div className="border-width" style={{ left: '0', bottom: '-4px' }}></div>
+        <div className="border-height" style={{ right: '4px', top: '0' }}></div>
+        <div>
+          <p style={{ color: '#0A0A0A', fontSize: '24px' }}>{text}</p>
+        </div>
+        <p>{text}</p>
+        <BubbleBox>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+        </BubbleBox>
+      </div>
+    </BubbleContentsLayout>
+  );
+};
+
+const BubbleContentsLayout = styled.div<{ height: number }>`
+  position: absolute;
+  top: ${(props) => -props.height - 20}px;
+  right: -20px;
+  width: 500px;
+  min-height: 48px;
+  & > div:first-child {
+    position: relative;
+    width: 500px;
+    min-height: 48px;
+    padding: 10px 8px;
+  }
+  & > div > .border-width {
+    position: absolute;
+    width: 492px;
+    height: 4px;
+    background-color: black;
+  }
+  & > div > .border-height {
+    position: absolute;
+    width: 4px;
+    height: 100%;
+    background-color: black;
+  }
+  & > div > div:nth-child(5) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 492px;
+    height: 100%;
+    padding: 10px 8px;
+    background-color: white;
+  }
+  & > div > p {
+    visibility: hidden;
+    font-size: 24px;
+    line-height: 110%;
+  }
+`;
+
+const BubbleBox = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  bottom: -16px;
+  right: 28px;
+  width: 20px;
+  height: 16px;
+  & > div {
+    height: 4px;
+    background-color: white;
+  }
+  & > div:first-child {
+    width: 20px;
+    border-top: 1px solid white;
+  }
+  & > div:nth-child(2) {
+    width: 12px;
+    box-shadow: -4px 0px 0px 0px black, 4px 0px 0px 0px black;
+  }
+  & > div:nth-child(3) {
+    width: 4px;
+    box-shadow: -4px 0px 0px 0px black, 4px 0px 0px 0px black;
+  }
+  & > div:nth-child(4) {
+    width: 4px;
+    background-color: black;
+  }
+`;
+
+export default BubbleContents;

--- a/src/components/game/Presenter.tsx
+++ b/src/components/game/Presenter.tsx
@@ -52,7 +52,7 @@ const Presenter = () => {
     if (isEvaluatable()) {
       alertToast(`정답은 "${turn?.keyword}" 입니다.`, 'success', {
         hideProgressBar: true,
-        autoClose: 9000,
+        autoClose: 3000,
       });
     }
   }, [playState]);

--- a/src/components/game/PresenterKeywordBox.tsx
+++ b/src/components/game/PresenterKeywordBox.tsx
@@ -11,8 +11,9 @@ export interface PresenterKeywordBoxProps {
 const PresenterKeywordBox = ({ isMe, keyword, answered }: PresenterKeywordBoxProps) => {
   return (
     <PresenterKeywordLayout>
+      {keyword.length > 12 && <p>제시어</p>}
       <p>
-        제시어:&nbsp;
+        {keyword.length <= 12 && <span>제시어:&nbsp;</span>}
         <KeywordText isMe={isMe} answered={answered ?? false}>
           {isMe || answered ? keyword : filterKeyword(keyword)}
         </KeywordText>
@@ -39,7 +40,8 @@ const PresenterKeywordLayout = styled.div`
   display: flex;
   width: 100%;
   justify-content: center;
-  align-items: flex-end;
+  align-items: center;
+  flex-direction: column;
   top: 38px;
   background-color: rgba(28, 28, 28, 0.7);
   z-index: 3;

--- a/src/stories/common/BubbleContents.stories.tsx
+++ b/src/stories/common/BubbleContents.stories.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import BubbleContents, { BubbleContentsProps } from '@components/common/BubbleContents';
+
+export default {
+  title: 'common/BubbleContents',
+  component: BubbleContents,
+  parameters: {
+    controls: {
+      exclude: ['onMouseLeave'],
+    },
+  },
+} as ComponentMeta<typeof BubbleContents>;
+
+const Template: ComponentStory<typeof BubbleContents> = (args: BubbleContentsProps) => {
+  const [visible, setVisible] = useState<boolean>(false);
+  return (
+    <div>
+      <div style={{ width: '30px', height: '30px', position: 'relative' }}>
+        <button onMouseOver={() => setVisible(true)}>보기</button>
+        {visible && <BubbleContents {...args} onMouseLeave={() => setVisible(false)} />}
+      </div>
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  text: 'hello world',
+};

--- a/src/types/socketType.ts
+++ b/src/types/socketType.ts
@@ -89,4 +89,5 @@ export interface GameTurnInfoResponse {
   speechPlayer: number;
   keyword: string;
   answered?: boolean;
+  hint: string;
 }


### PR DESCRIPTION
### Issue

- resolves #231 

<br>

### 요약

게임 진행 시 키워드 힌트를 보여줄 수 있다.

<br>

### 작업 내용

- 키워드 이벤트 아이콘 및 말풍선 UI 구성
- 발표자가 준비 시간에 힌트를 확인할 수 있다.
- 토론 시간에 모두가 힌트를 확인할 수 있다.

<br>

### 리뷰어에게 할 말

말풍선 아랫부분에 구분선이 있는데 어떻게 없애야할까요

<br>


 
