### PR TITLE
FIX: 공지 모달이 페이지 이동 시 다시 나오는 문제 처리하기

### DIFF
--- a/src/components/home/AnnouncementModal.tsx
+++ b/src/components/home/AnnouncementModal.tsx
@@ -30,7 +30,7 @@ const AnnouncementModal = ({ visible, onClose }: { visible: boolean; onClose: ()
   };
 
   return (
-    <Modal visible={visible} onClose={onClose} title="ANNOUNCEMENT">
+    <Modal visible={visible} onClose={onClose} title="ANNOUNCEMENT" isBackgroundClickEventDisabled={false}>
       <AnnouncementModalLayout>
         <ul>
           <li>
@@ -55,10 +55,8 @@ const AnnouncementModal = ({ visible, onClose }: { visible: boolean; onClose: ()
           <li className="important">가능한 중도에 나가기 버튼은 지양해주세요!</li>
           <br />
           <br />
-          <li>
-            <span onClick={handleClickShowOnlyTodaySpan} style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              오늘 하루 보지 않기
-            </span>
+          <li style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <span onClick={handleClickShowOnlyTodaySpan}>오늘 하루 보지 않기</span>
           </li>
         </ul>
       </AnnouncementModalLayout>

--- a/src/components/home/AnnouncementModal.tsx
+++ b/src/components/home/AnnouncementModal.tsx
@@ -1,11 +1,21 @@
+import { useEffect } from 'react';
+
 import styled from 'styled-components';
 
 import cursorIcon from '@assets/svg_cursorIcon.svg';
 import gameRuleIcon from '@assets/svg_gameRuleIcon.svg';
+import { useAppDispatch } from '@redux/hooks';
+import { setMainNotificationShown } from '@redux/modules/notificationSlice';
 
 import Modal from '@components/common/Modal';
 
 const AnnouncementModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(setMainNotificationShown());
+  }, []);
+
   const handleClickShowOnlyTodaySpan = () => {
     const date = new Date();
 

--- a/src/components/home/SpecialNotificationModal.tsx
+++ b/src/components/home/SpecialNotificationModal.tsx
@@ -33,7 +33,7 @@ const SpecialNotificationModal = ({ visible, onClose, contents, notificaionKey }
   return (
     <>
       {!notVisibleToday() && (
-        <Modal visible={visible} onClose={onClose}>
+        <Modal visible={visible} onClose={onClose} isBackgroundClickEventDisabled={false}>
           <SpecialNotificationModalLayout>
             <h1>특 별 공 지</h1>
             <p>{contents}</p>

--- a/src/hooks/useSpecialNotification.tsx
+++ b/src/hooks/useSpecialNotification.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react';
 
 import axios from 'axios';
 
+import { useAppDispatch, useAppSelector } from '@redux/hooks';
+import { setSpecialNotificationShown } from '@redux/modules/notificationSlice';
+
 interface NotificationType {
   hasAlert: string;
   contents: string;
@@ -9,21 +12,24 @@ interface NotificationType {
 }
 
 const useSpecialNotification = () => {
-  const lambdaNotificationURL = process.env.REACT_APP_LAMBDA_NOTI;
+  const dispatch = useAppDispatch();
+  const { isSpecialNotificationShown } = useAppSelector((state) => state.notification);
   const [hasNotification, setHasNotification] = useState<boolean>(false);
   const [contents, setContents] = useState<string>('');
   const [key, setKey] = useState<string>('');
+  const lambdaNotificationURL = process.env.REACT_APP_LAMBDA_NOTI;
   useEffect(() => {
-    if (!lambdaNotificationURL) {
+    if (!lambdaNotificationURL || isSpecialNotificationShown) {
       return;
     }
     (async () => {
-      const notificationResult = await axios.get('https://au12xtunpb.execute-api.ap-northeast-2.amazonaws.com/prod');
+      const notificationResult = await axios.get(lambdaNotificationURL);
       const data = notificationResult.data.body as NotificationType;
       if (data.hasAlert === 'true') {
         setHasNotification(true);
         setContents(data.contents);
         setKey(data.key);
+        dispatch(setSpecialNotificationShown());
       }
     })();
   }, []);

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import useErrorSocket from '@hooks/socket/useErrorSocket';
 import useDuplicatedUserInvalidate from '@hooks/useDuplicatedUserInvalidate';
 import useSpecialNotification from '@hooks/useSpecialNotification';
+import { useAppSelector } from '@redux/hooks';
 import { useGetUserInfoQuery, useLazyGetLogoutQuery } from '@redux/query/user';
 
 import AnnouncementModal from '@components/home/AnnouncementModal';
@@ -16,7 +17,7 @@ import MainTemplate from '@components/layout/MainTemplate';
 const Main = () => {
   const { data } = useGetUserInfoQuery();
   const user = data;
-
+  const { isMainNotificationShown } = useAppSelector((state) => state.notification);
   const { onError, offError } = useErrorSocket();
   const { invalidate } = useDuplicatedUserInvalidate();
   const [doLogout] = useLazyGetLogoutQuery();
@@ -56,7 +57,7 @@ const Main = () => {
     const AnnouncementModalShownDate = localStorage.getItem('AnnouncementModalShownDate');
 
     if (user && AnnouncementModalShownDate !== currentDate) {
-      setAnnouncementModalVisible(true);
+      setAnnouncementModalVisible(true && !isMainNotificationShown);
     }
   }, [user]);
 

--- a/src/redux/modules/notificationSlice.ts
+++ b/src/redux/modules/notificationSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface NotificationStateType {
+  isMainNotificationShown?: boolean;
+  isSpecialNotificationShown?: boolean;
+}
+
+const initialState: NotificationStateType = {};
+
+const notificationSlice = createSlice({
+  name: 'notification',
+  initialState,
+  reducers: {
+    setMainNotificationShown: (state) => {
+      state.isMainNotificationShown = true;
+    },
+    setSpecialNotificationShown: (state) => {
+      state.isSpecialNotificationShown = true;
+    },
+  },
+  extraReducers: {},
+});
+
+export const { setMainNotificationShown, setSpecialNotificationShown } = notificationSlice.actions;
+
+export default notificationSlice;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,6 +6,7 @@ import type { Middleware } from '@reduxjs/toolkit';
 
 import gamePlaySlice from './modules/gamePlaySlice';
 import gameRoomSlice from './modules/gameRoomSlice';
+import notificationSlice from './modules/notificationSlice';
 import playerMediaSlice from './modules/playerMediaSlice';
 import userMediaSlice from './modules/userMediaSlice';
 import { coreApi } from './query/coreApi';
@@ -15,6 +16,7 @@ const rootReducer = combineReducers({
   userMedia: userMediaSlice.reducer,
   playerMedia: playerMediaSlice.reducer,
   gamePlay: gamePlaySlice.reducer,
+  notification: notificationSlice.reducer,
   [coreApi.reducerPath]: coreApi.reducer,
 });
 


### PR DESCRIPTION
### Issue

- resolves #238 

<br>

### 요약

공지 모달이 페이지 이동 시 다시 나오는 문제 처리하기 

<br>

### 작업 내용

- 공지 클라이언트 상태/리듀서 추가
- 전역 상태 관리로 한 번의 페이지 주기동안은 다시 안 뜨도록 개선
- 공지 모달들에 clickaway 설정

![modal](https://user-images.githubusercontent.com/76927397/217934027-f3f80eba-54c3-4053-bcca-4ec23587b0c6.gif)


<br>

 
