### PR TITLE
FIX: 닉네임 수정 관련 누락된 동작 추가하기

### DIFF
--- a/src/components/home/SetUpInfo.tsx
+++ b/src/components/home/SetUpInfo.tsx
@@ -15,6 +15,7 @@ import yellowRocketImage from '@assets/png_yellowRocketImage.png';
 import { CatTheme, RocketTheme } from '@constants/characters';
 import { useGetUserInfoQuery, useUpdateUserInfoMutation } from '@redux/query/user';
 import { getCatInfoByQuery } from '@utils/character';
+import { alertToast } from '@utils/toast';
 
 import Cat from '@components/character/Cat';
 import Button from '@components/common/Button';
@@ -35,8 +36,7 @@ const SetUpInfo = ({
   const { cat, rocket } = getCatInfoByQuery(user?.profileImg);
   const [newNickname, setNewNickname] = useState<string>(user?.nickname ?? '');
   const [prevCheckedNickname, setPrevCheckedNickname] = useState<string>('');
-  const [duplicateAlert, setDuplicateAlert] = useState<{ duplicate: boolean; message: string }>({
-    duplicate: false,
+  const [duplicateAlert, setDuplicateAlert] = useState<{ duplicate?: boolean; message: string }>({
     message: '',
   });
   const [newCat, setNewCat] = useState<CatTheme>(cat);
@@ -74,7 +74,10 @@ const SetUpInfo = ({
       !mypage && isSetUpInfoSuccess((prev) => !prev);
       return null;
     }
-    if (duplicateAlert.duplicate) {
+    if (user?.nickname !== newNickname && (duplicateAlert.duplicate || duplicateAlert.duplicate === undefined)) {
+      alertToast('닉네임 중복을 확인하세요!', 'warning', {
+        hideProgressBar: true,
+      });
       return;
     }
     if (user?.nickname === newNickname && user?.profileImg !== newProfileImg) {
@@ -95,20 +98,24 @@ const SetUpInfo = ({
     }
   };
 
+  const handleNicknameInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputNickname = e.target.value.replace(/\s/g, '');
+    setNewNickname(inputNickname);
+    setDuplicateAlert({ duplicate: undefined, message: user?.nickname === inputNickname ? '현재 닉네임입니다.' : '' });
+    setPrevCheckedNickname('');
+  };
+
   return (
     <SetUpInfoLayout cat={newCat} rocket={newRocket}>
       <LeftSectionBox>
         <InputContainer label="닉네임">
-          <NicknameInputBox duplicate={duplicateAlert.duplicate}>
-            <input
-              type="text"
-              maxLength={10}
-              value={newNickname}
-              onChange={(e) => setNewNickname(e.target.value.replace(/\s/g, ''))}
-            />
+          <NicknameInputBox duplicate={duplicateAlert.duplicate ?? false}>
+            <input type="text" maxLength={10} value={newNickname} onChange={handleNicknameInputChange} />
             <button onClick={handleDuplicateCheckButtonClick}>중복확인</button>
           </NicknameInputBox>
-          <NicknameDuplicateAlert duplicate={duplicateAlert.duplicate}>{duplicateAlert.message}</NicknameDuplicateAlert>
+          <NicknameDuplicateAlert duplicate={duplicateAlert.duplicate ?? false}>
+            {duplicateAlert.message}
+          </NicknameDuplicateAlert>
         </InputContainer>
         <InputContainer label="적용 캐릭터">
           <SelectedCharacterBox>


### PR DESCRIPTION
### Issue

- resolves #240 

<br>

### 요약

닉네임 수정 관련 누락된 동작 추가하기

<br>

### 작업 내용

- 닉네임 변경이 있을 경우 중복확인 해야 수정할 수 있도록 개선 

- 편의성을 위해 닉네임 input 변경 시 메시지 몇 개 추가

**닉네임 중복 체크 안하면 제출 안되게 추가**

![nick1](https://user-images.githubusercontent.com/76927397/217942674-13784f1f-7d5e-4b88-83c9-af3ff05eff95.gif)


**input 변경 시 닉네임 중복체크 상태를 초기화시키고 기존 닉네임이라면 그렇다고 알려주고 아니라면 변경 후 중복체크를 했었는지 잊을 불편함을 없애보고자함**

![nick2](https://user-images.githubusercontent.com/76927397/217942879-c83bdd70-d051-4baf-a29f-11f5dbf9a002.gif)




<br>

### 리뷰어에게 할 말

진작 확인했어야 하는 것을 놓쳤네요!

<br>

 
